### PR TITLE
Fix theme path and CSP inline script

### DIFF
--- a/app.js
+++ b/app.js
@@ -134,6 +134,7 @@ function getModuleTokenForDbManager() {
   app.use('/admin/assets', express.static(path.join(publicPath, 'assets')));
   app.use('/assets/plainspace', express.static(path.join(assetsPath, 'plainspace')));
   app.use('/assets', express.static(assetsPath));
+  app.use('/themes', express.static(path.join(publicPath, 'themes')));
   app.use('/favicon.ico', express.static(path.join(publicPath,'favicon.ico')));
   app.use('/fonts', express.static(path.join(publicPath,'fonts')));
 

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,6 @@
   <link rel="stylesheet" href="/assets/css/gridstack.min.css" />
 
   <!-- Theme styles -->
-  <script>window.ACTIVE_THEME = 'default';</script>
   <link rel="stylesheet" href="/themes/default/theme.css" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- serve the `/themes` directory via express.static so theme CSS files have the correct MIME type
- remove inline script from `public/index.html` to satisfy Content Security Policy

## Testing
- `npm test`