### PR TITLE
Add settings page styling

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/partials/settings-sidebar.html
+++ b/BlogposterCMS/public/assets/plainspace/admin/partials/settings-sidebar.html
@@ -1,9 +1,21 @@
 <div class="sidebar">
-    <nav class="sidebar-nav">
-      <a href="/admin/settings/system"><img src="/assets/icons/server.svg" class="icon" /> System</a>
-      <a href="/admin/settings/users"><img src="/assets/icons/users.svg" class="icon" /> Users</a>
-      <a href="/admin/settings/modules"><img src="/assets/icons/package.svg" class="icon" /> Modules</a>
-      <a href="/admin/settings/themes"><img src="/assets/icons/layout.svg" class="icon" /> Themes</a>
-    </nav>
-  </div>
+  <nav class="sidebar-nav">
+    <a href="/admin/settings/system" class="sidebar-item">
+      <img src="/assets/icons/server.svg" class="icon" alt="System" />
+      <span class="label">System</span>
+    </a>
+    <a href="/admin/settings/users" class="sidebar-item">
+      <img src="/assets/icons/users.svg" class="icon" alt="Users" />
+      <span class="label">Users</span>
+    </a>
+    <a href="/admin/settings/modules" class="sidebar-item">
+      <img src="/assets/icons/package.svg" class="icon" alt="Modules" />
+      <span class="label">Modules</span>
+    </a>
+    <a href="/admin/settings/themes" class="sidebar-item">
+      <img src="/assets/icons/layout.svg" class="icon" alt="Themes" />
+      <span class="label">Themes</span>
+    </a>
+  </nav>
+</div>
   

--- a/BlogposterCMS/public/assets/scss/components/_sidebar-bubble.scss
+++ b/BlogposterCMS/public/assets/scss/components/_sidebar-bubble.scss
@@ -62,10 +62,20 @@
           opacity: 1;
           transform: translateY(-50%) translateX(8px) scale(1);
         }
-      
+
         border: 1px solid var(--gradient-primary);
         border-radius: 999px;
         box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+      }
+
+      &.active {
+        background: var(--gradient-primary);
+        border-radius: 999px;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+
+        .icon {
+          fill: var(--color-white);
+        }
       }
     }
   }

--- a/BlogposterCMS/public/assets/scss/pages/_settings.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_settings.scss
@@ -1,0 +1,25 @@
+/* =============================================================================
+   Settings Page Styles
+   ============================================================================= */
+.settings-page {
+  display: flex;
+  gap: 20px;
+}
+
+.settings-content {
+  flex: 1;
+  background: #fff;
+  padding: 24px;
+  border-radius: 14px;
+  box-shadow: 0 6px 24px rgba(0,0,0,0.07);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+

--- a/BlogposterCMS/public/assets/scss/site.scss
+++ b/BlogposterCMS/public/assets/scss/site.scss
@@ -14,5 +14,6 @@
 @import 'components/content-header';
 @import 'pages/pages';
 @import 'pages/media';
+@import 'pages/settings';
 @import 'components/builder';
 @import 'components/page-editor';


### PR DESCRIPTION
## Summary
- add bubble-style classes to settings sidebar links
- style bubble menu active state
- style settings content layout via SCSS and import in main stylesheet
- revert compiled CSS file to avoid editing generated output

## Testing
- `npm test` *(fails: `npm` not installed)*