### PR TITLE
Add heading widget with level selector

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/public/headingWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/headingWidget.js
@@ -1,10 +1,56 @@
 export function render(el, ctx = {}) {
-  const h = document.createElement('h3');
-  h.textContent = ctx?.metadata?.label || 'Section Heading';
+  const defaultLevel = (ctx?.metadata?.category || 'h3').toLowerCase();
+  const defaultText = ctx?.metadata?.label || 'Section Heading';
+
+  let level = defaultLevel;
+  let heading = document.createElement(level);
+  heading.textContent = defaultText;
+
+  const container = document.createElement('div');
+  container.className = 'heading-widget';
+  container.appendChild(heading);
+
   if (ctx.jwt) {
-    h.contentEditable = 'true';
-    h.addEventListener('blur', async () => {
-      const newText = h.textContent.trim();
+    heading.contentEditable = 'true';
+
+    const select = document.createElement('select');
+    select.className = 'heading-level-select';
+    for (let i = 1; i <= 6; i++) {
+      const tag = `h${i}`;
+      const opt = document.createElement('option');
+      opt.value = tag;
+      opt.textContent = tag.toUpperCase();
+      if (tag === level) opt.selected = true;
+      select.appendChild(opt);
+    }
+
+    select.addEventListener('change', async () => {
+      const newLevel = select.value;
+      if (newLevel !== level) {
+        const newHeading = document.createElement(newLevel);
+        newHeading.textContent = heading.textContent;
+        newHeading.contentEditable = 'true';
+        container.replaceChild(newHeading, heading);
+        heading = newHeading;
+        level = newLevel;
+
+        try {
+          await window.meltdownEmit('updateWidget', {
+            jwt: ctx.jwt,
+            moduleName: 'widgetManager',
+            moduleType: 'core',
+            widgetId: ctx.id,
+            widgetType: 'public',
+            newCategory: newLevel
+          });
+        } catch (err) {
+          console.error('[headingWidget] level save error', err);
+        }
+      }
+    });
+
+    heading.addEventListener('blur', async () => {
+      const newText = heading.textContent.trim();
       try {
         await window.meltdownEmit('updateWidget', {
           jwt: ctx.jwt,
@@ -18,7 +64,10 @@ export function render(el, ctx = {}) {
         console.error('[headingWidget] save error', err);
       }
     });
+
+    container.appendChild(select);
   }
+
   el.innerHTML = '';
-  el.appendChild(h);
+  el.appendChild(container);
 }

--- a/BlogposterCMS/public/assets/scss/components/_heading-widget.scss
+++ b/BlogposterCMS/public/assets/scss/components/_heading-widget.scss
@@ -1,0 +1,8 @@
+.heading-widget {
+  display: flex;
+  align-items: center;
+
+  .heading-level-select {
+    margin-left: 8px;
+  }
+}

--- a/BlogposterCMS/public/assets/scss/site.scss
+++ b/BlogposterCMS/public/assets/scss/site.scss
@@ -16,5 +16,6 @@
 @import 'pages/media';
 @import 'pages/settings';
 @import 'components/builder';
+@import 'components/heading-widget';
 @import 'components/page-editor';
 @import 'pages/users';


### PR DESCRIPTION
## Summary
- enhance heading widget to choose heading level (H1–H6) while editing
- style heading widget and level dropdown in SCSS
- remove direct CSS modification and rely on SCSS

## Testing
- `npm --prefix BlogposterCMS test`
