### PR TITLE
Add media explorer image widget

### DIFF
--- a/BlogposterCMS/public/admin.html
+++ b/BlogposterCMS/public/admin.html
@@ -31,6 +31,7 @@
 
   <!-- 2) Meltdown-Emitter wrapper (ES-module, needs the global above) -->
   <script type="module" src="/assets/js/meltdownEmitter.js"></script>
+  <script src="/assets/js/openExplorer.js"></script>
 
   <!-- Quill rich text editor -->
   <script src="/assets/js/quill.js"></script>

--- a/BlogposterCMS/public/assets/js/meltdownEmitter.js
+++ b/BlogposterCMS/public/assets/js/meltdownEmitter.js
@@ -1,6 +1,9 @@
 // public/assets/js/meltdownEmitter.js
 ;(function(window) {
   window.meltdownEmit = async function(eventName, payload = {}) {
+    if (eventName === 'openExplorer' && window._openMediaExplorer) {
+      return window._openMediaExplorer(payload);
+    }
     const headers = {
       'Content-Type': 'application/json'
     };

--- a/BlogposterCMS/public/assets/js/openExplorer.js
+++ b/BlogposterCMS/public/assets/js/openExplorer.js
@@ -1,0 +1,100 @@
+;(function(window){
+  async function openMediaExplorer(opts = {}) {
+    const jwt = opts.jwt || window.ADMIN_TOKEN || window.PUBLIC_TOKEN;
+    if (!jwt) throw new Error('openExplorer: missing JWT');
+    const subPath = opts.subPath || 'public';
+
+    return new Promise((resolve, reject) => {
+      const dialog = document.createElement('dialog');
+      dialog.className = 'media-explorer';
+
+      const closeBtn = document.createElement('button');
+      closeBtn.textContent = '×';
+      closeBtn.className = 'close-btn';
+      closeBtn.onclick = () => { dialog.close(); reject(new Error('cancelled')); };
+
+      const uploadBtn = document.createElement('button');
+      uploadBtn.textContent = 'Upload';
+      const fileInput = document.createElement('input');
+      fileInput.type = 'file';
+      fileInput.accept = 'image/*';
+      fileInput.style.display = 'none';
+      uploadBtn.onclick = () => fileInput.click();
+      fileInput.onchange = async e => {
+        const file = e.target.files[0];
+        if (!file) return;
+        const form = new FormData();
+        form.append('file', file);
+        try {
+          const resp = await fetch('/admin/api/upload?subPath=' + encodeURIComponent(subPath), {
+            method: 'POST',
+            headers: { 'X-CSRF-Token': window.CSRF_TOKEN },
+            body: form,
+            credentials: 'same-origin'
+          });
+          const json = await resp.json();
+          if (!resp.ok || json.error) throw new Error(json.error || resp.statusText);
+          await loadList();
+        } catch(err) {
+          alert('Upload failed: ' + err.message);
+        }
+      };
+
+      const listEl = document.createElement('ul');
+      listEl.className = 'media-list';
+
+      dialog.appendChild(closeBtn);
+      dialog.appendChild(uploadBtn);
+      dialog.appendChild(fileInput);
+      dialog.appendChild(listEl);
+
+      async function choose(name) {
+        try {
+          const { shareURL } = await window.meltdownEmit('createShareLink', {
+            jwt,
+            moduleName: 'shareManager',
+            moduleType: 'core',
+            filePath: subPath + '/' + name
+          });
+          dialog.close();
+          resolve({ shareURL, name });
+        } catch(err) {
+          alert('Error: ' + err.message);
+        }
+      }
+
+      async function loadList() {
+        try {
+          const res = await window.meltdownEmit('listLocalFolder', {
+            jwt,
+            moduleName: 'mediaManager',
+            moduleType: 'core',
+            subPath
+          });
+          const files = res?.files || [];
+          listEl.innerHTML = '';
+          if (!files.length) {
+            const li = document.createElement('li');
+            li.textContent = 'No images found';
+            listEl.appendChild(li);
+          }
+          files.forEach(name => {
+            const li = document.createElement('li');
+            li.textContent = name;
+            li.onclick = () => choose(name);
+            listEl.appendChild(li);
+          });
+        } catch(err) {
+          listEl.innerHTML = `<li>Error: ${err.message}</li>`;
+        }
+      }
+
+      document.body.appendChild(dialog);
+      dialog.addEventListener('close', () => dialog.remove());
+      loadList();
+      dialog.showModal();
+    });
+  }
+
+  window._openMediaExplorer = openMediaExplorer;
+})(window);

--- a/BlogposterCMS/public/assets/plainspace/public/imageWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/imageWidget.js
@@ -1,45 +1,35 @@
 export function render(el, ctx = {}) {
   const img = document.createElement('img');
   img.src = ctx?.metadata?.category || '/assets/images/abstract-gradient-bg.png';
-  img.alt = 'Sample image';
+  img.alt = 'Image';
   img.style.width = '100%';
+
   el.innerHTML = '';
   el.appendChild(img);
 
   if (ctx.jwt) {
     const btn = document.createElement('button');
     btn.textContent = 'Choose Image';
-    btn.onclick = async () => {
+    btn.addEventListener('click', async () => {
       try {
-        const list = await window.meltdownEmit('listLocalFolder', {
-          jwt: ctx.jwt,
-          moduleName: 'mediaManager',
-          moduleType: 'core',
-          subPath: 'public'
-        });
-        const files = list?.files || [];
-        if (!files.length) return alert('No images found');
-        const choice = prompt('Image file name:', files[0]);
-        if (!choice) return;
-        const { shareURL } = await window.meltdownEmit('createShareLink', {
-          jwt: ctx.jwt,
-          moduleName: 'shareManager',
-          moduleType: 'core',
-          filePath: 'public/' + choice
-        });
-        img.src = shareURL;
-        await window.meltdownEmit('updateWidget', {
-          jwt: ctx.jwt,
-          moduleName: 'widgetManager',
-          moduleType: 'core',
-          widgetId: ctx.id,
-          widgetType: 'public',
-          newCategory: shareURL
-        });
+        const { shareURL } = await window.meltdownEmit('openExplorer', { jwt: ctx.jwt });
+        if (shareURL) {
+          img.src = shareURL;
+          await window.meltdownEmit('updateWidget', {
+            jwt: ctx.jwt,
+            moduleName: 'widgetManager',
+            moduleType: 'core',
+            widgetId: ctx.id,
+            widgetType: 'public',
+            newCategory: shareURL
+          });
+        }
       } catch (err) {
-        console.error('[imageWidget] select error', err);
+        console.error('[imageWidget] openExplorer error', err);
       }
-    };
+    });
     el.appendChild(btn);
   }
+
 }
+

--- a/BlogposterCMS/public/index.html
+++ b/BlogposterCMS/public/index.html
@@ -19,6 +19,8 @@
   <script src="/assets/js/gridstack.all.js"></script>
   <!-- miniEmitter: your single Meltdown API tunnel -->
   <script src="/assets/js/meltdownEmitter.js"></script>
+  <!-- global media explorer -->
+  <script src="/assets/js/openExplorer.js"></script>
   <!-- Your pageRenderer, which now just calls miniEmitter(...) -->
   <script type="module" src="/assets/js/pageRenderer.js"></script>
 </body>

--- a/BlogposterCMS/public/pages.html
+++ b/BlogposterCMS/public/pages.html
@@ -16,6 +16,7 @@
   <script src="/assets/js/gridstack.all.js"></script>
   <!-- meltdownEmitter sets window.meltdownEmit -->
   <script src="/assets/js/meltdownEmitter.js"></script>
+  <script src="/assets/js/openExplorer.js"></script>
   <!-- Your ES-module picker -->
   <script type="module" src="/assets/plainSpace/admin/pagePicker.js"></script>
 </body>

--- a/BlogposterCMS/webpack.config.js
+++ b/BlogposterCMS/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
     register: './public/assets/js/register.js',
     sortable: './public/assets/js/sortable.min.js',
     tokenLoader: './public/assets/js/tokenLoader.js',
-    topHeaderActions: './public/assets/js/topHeaderActions.js'
+    topHeaderActions: './public/assets/js/topHeaderActions.js',
+    openExplorer: './public/assets/js/openExplorer.js'
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
## Summary
- wire global `openExplorer` event via meltdownEmitter
- implement `openExplorer` media dialog
- update public image widget to use the global event
- include new script in HTML pages

## Testing
- `npm test --prefix BlogposterCMS`