### PR TITLE
Fix Quill imports for blob contexts

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -1,10 +1,15 @@
 // public/assets/plainspace/admin/builderRenderer.js
-// Use an absolute path so the module works even when executed from a blob
-// context (e.g. during inline code execution inside the builder). Relative
-// imports fail in that scenario because the base URL is not hierarchical.
-import { initQuill } from '/assets/js/quillEditor.js';
+// Dynamically load the Quill helper. Using a fully qualified URL ensures
+// the module can be resolved even when this file runs from a `blob:` URL
+// (for example when evaluating user-provided code in the builder).
+const quillModuleUrl = new URL('/assets/js/quillEditor.js', document.baseURI).href;
+
+let initQuill;
 
 export async function initBuilder(sidebarEl, contentEl, pageId = null) {
+  if (!initQuill) {
+    ({ initQuill } = await import(quillModuleUrl));
+  }
   document.body.classList.add('builder-mode');
   // Temporary patch: larger default widget height
   const DEFAULT_ROWS = 20; // around 100px with 5px grid cells

--- a/BlogposterCMS/public/assets/plainspace/admin/pageEditorWidgets/pageInfoWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/pageEditorWidgets/pageInfoWidget.js
@@ -1,8 +1,10 @@
-// Use an absolute path for compatibility when this widget's code is executed
-// from a blob URL inside the builder's inline editor.
-import { initQuill } from '/assets/js/quillEditor.js';
+// The builder may execute this code from a `blob:` URL. Loading Quill
+// dynamically with a full URL ensures the import succeeds in that case.
+// Dynamically import Quill so this widget works when executed from a blob URL.
+const quillUrl = new URL('/assets/js/quillEditor.js', document.baseURI).href;
 
 export async function render(el) {
+  const { initQuill } = await import(quillUrl);
   const pageData = await window.pageDataLoader.load('getPageById', {
     moduleName: 'pagesManager',
     moduleType: 'core',

--- a/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
@@ -1,8 +1,9 @@
-// Absolute path ensures Quill loads correctly even when this widget code is
-// evaluated from a blob during live editing.
-import { initQuill } from '/assets/js/quillEditor.js';
+// The editor may run from a `blob:` URL when edited live. Load Quill
+// dynamically using an absolute URL so the import succeeds in that case.
+const quillUrl = new URL('/assets/js/quillEditor.js', document.baseURI).href;
 
-export function render(el, ctx = {}) {
+export async function render(el, ctx = {}) {
+  const { initQuill } = await import(quillUrl);
   const container = document.createElement('div');
   container.className = 'text-block-widget';
   container.innerHTML = ctx?.metadata?.label || '<p>Sample text block</p>';


### PR DESCRIPTION
## Summary
- resolve Quill import when builder code is executed from a blob
- load Quill dynamically in textBlockWidget
- load Quill dynamically in pageInfoWidget

## Testing
- `npm test`