### PR TITLE
Enable openMediaExplorer for image uploads

### DIFF
--- a/BlogposterCMS/public/assets/js/meltdownEmitter.js
+++ b/BlogposterCMS/public/assets/js/meltdownEmitter.js
@@ -1,7 +1,10 @@
 // public/assets/js/meltdownEmitter.js
 ;(function(window) {
   window.meltdownEmit = async function(eventName, payload = {}) {
-    if (eventName === 'openExplorer' && window._openMediaExplorer) {
+    if (
+      (eventName === 'openExplorer' || eventName === 'openMediaExplorer') &&
+      window._openMediaExplorer
+    ) {
       return window._openMediaExplorer(payload);
     }
     const headers = {

--- a/BlogposterCMS/public/assets/plainspace/public/imageWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/imageWidget.js
@@ -12,7 +12,7 @@ export function render(el, ctx = {}) {
     btn.textContent = 'Choose Image';
     btn.addEventListener('click', async () => {
       try {
-        const { shareURL } = await window.meltdownEmit('openExplorer', { jwt: ctx.jwt });
+        const { shareURL } = await window.meltdownEmit('openMediaExplorer', { jwt: ctx.jwt });
         if (shareURL) {
           img.src = shareURL;
           await window.meltdownEmit('updateWidget', {
@@ -25,7 +25,7 @@ export function render(el, ctx = {}) {
           });
         }
       } catch (err) {
-        console.error('[imageWidget] openExplorer error', err);
+        console.error('[imageWidget] openMediaExplorer error', err);
       }
     });
     el.appendChild(btn);


### PR DESCRIPTION
## Summary
- remove `penMediaExplorer` alias from `meltdownEmitter`
- call `openMediaExplorer` when choosing an image

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6838b13f2190832891a735a7897761ee