### PR TITLE
Add explanation for page hierarchy and builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Additional documentation files live in the [docs](docs/) directory:
 - [Installation](docs/installation.md)
 - [Module Architecture](docs/modules.md)
 - [Security Notes](docs/security.md)
+- [CMS Usage Guide](docs/guide.md)
 
 ## License
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,68 @@
+# CMS Usage Guide
+
+This guide describes how to operate BlogposterCMS once the server is running. It covers the dashboard, the two widget lanes, and the JWT event bus that modules use.
+
+## Accessing the Dashboard
+
+1. Start the server using `npm start`.
+2. Open `http://localhost:3000/` in your browser.
+3. The admin interface lives under `/admin`.
+4. If you are accessing for the first time, register or create an admin user via the command line utilities.
+5. Log in with your credentials to see the dashboard.
+
+The dashboard allows you to manage pages, users and settings. Only authenticated users with the appropriate role can access it. Always use HTTPS in production so credentials are transmitted securely.
+
+## Admin Lane vs Public Lane
+
+BlogposterCMS separates widgets and pages into **admin** and **public** lanes:
+
+- **Public lane** pages are visible to regular visitors.
+- **Admin lane** pages are only accessible in the dashboard for editing and management tasks.
+
+Each lane has its own widget registry so that sensitive admin widgets are never loaded on the public site. If a page is misconfigured and tries to request admin widgets while rendering publicly, the renderer forces the lane back to `public` for security.
+
+## Widgets Overview
+
+Widgets are small blocks of functionality (text blocks, images, counters, etc.) that you can place on pages. They are stored in the database through the `widgetManager` module.
+
+- Widgets registered for the **public** lane render on live pages.
+- Widgets registered for the **admin** lane appear in the dashboard for building pages or showing statistics.
+
+Layouts and widgets are edited via drag and drop in the admin dashboard. The widget manager ensures only users with the appropriate permissions can create or modify widgets.
+
+## Module System and JWT Event Bus
+
+All features communicate through the *meltdown* event bus. Events are signed with JSON Web Tokens (JWTs) to enforce permissions. The `motherEmitter` verifies each token before allowing a module to perform an action. Core modules receive high-trust tokens while optional modules run with lower trust levels.
+
+Example event call:
+
+```js
+motherEmitter.emit('dbSelect', {
+  jwt,
+  moduleName: 'myModule',
+  moduleType: 'community',
+  table: 'posts',
+  where: { id: 1 }
+}, callback);
+```
+
+The callback receives results only if the token has the `db.read` permission. This design prevents rogue modules from executing unauthorized database actions.
+
+## Building a Module
+
+1. Create a new folder under `modules/`.
+2. Add an `index.js` that exports an `initialize({ motherEmitter, jwt, isCore })` function.
+3. Inside `initialize`, register any meltdown event listeners your module needs.
+4. Include a `moduleInfo.json` file describing your module (name, version, permissions, etc.).
+5. Restart the server. The Module Loader will automatically attempt to load the new module inside its sandbox.
+
+Modules should only interact with the rest of the CMS through meltdown events. Refer to existing core modules for practical examples.
+
+
+## Page Hierarchy (No PostType)
+
+BlogposterCMS does not use a traditional `post.type` column. Instead content is organized by nesting pages. When creating a page you may supply `parent_id` to specify its parent. For example, create a page called `Blog` and then create "How to create a page in BlogposterCMS" with `parent_id` set to the Blog page's ID. The second page becomes a subpage. A future update will allow attaching custom fields to the parent; all subpages will automatically inherit values from those fields.
+
+## Page Builder and Lightweight UI
+
+The admin lane provides a drag‑and‑drop page builder at `/admin/builder`. The builder retrieves the widget registry via `widget.registry.request.v1` and loads widgets dynamically. Because it relies on minimal JavaScript and CSS, the interface remains lightweight and quick to load even on modest devices.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,5 +5,6 @@ Welcome to the documentation folder for **BlogposterCMS**. This section provides
 - [Installation](installation.md)
 - [Module Architecture](modules.md)
 - [Security Notes](security.md)
+- [CMS Usage Guide](guide.md)
 
 For the full project overview and sarcasm-filled introduction, see the main [README](../README.md).

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -7,3 +7,19 @@ BlogposterCMS follows a modular design. Core features and optional extensions ar
 - **Events** are used instead of direct function calls. Modules emit events to perform actions such as database operations, authentication or theme management. Tokens in the payload ensure that only authorised modules can request sensitive operations.
 
 When creating your own modules, start by exporting an `initialize` function that receives `{ motherEmitter, jwt, isCore }`. See the existing modules for reference.
+
+## The JWT Event Bus
+
+Modules communicate exclusively through the meltdown event bus. Every event payload contains a signed JWT that declares the module name, type and requested permissions. The `motherEmitter` validates these tokens before dispatching the event. If a token lacks the required permission, the call is rejected.
+
+This mechanism ensures that even community modules cannot bypass security boundaries. Always keep your JWT secrets private and avoid exposing them in logs or client-side code.
+
+## Creating a New Module
+
+1. Add a new folder under `modules/`.
+2. Place an `index.js` file inside it with an exported `initialize` function.
+3. Optionally include a `moduleInfo.json` file with metadata (name, version, permissions, description).
+4. Register any meltdown listeners within the `initialize` function. Use `motherEmitter.on('eventName', handler)` to react to events.
+5. Restart the CMS. The Module Loader will sandbox your module and activate it if no errors occur.
+
+Modules should avoid direct imports from other modules. Instead, emit events to request data or actions. This keeps modules loosely coupled and easier to maintain.

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,5 +7,6 @@ BlogposterCMS was designed with multiple layers of security in mind. While no sy
 - **Rate limiting** – The configuration in `config/security.js` defines limits for login attempts to slow down brute-force attacks. Adjust these values according to your needs.
 - **CSRF protection** – Admin routes use CSRF tokens to prevent cross-site request forgery. Clients must include the token when authenticating or performing sensitive actions.
 - **Module sandboxing** – Optional modules are loaded inside a sandbox. Faulty or malicious modules are deactivated automatically when health checks fail.
+- **JWT event bus** – All internal actions pass through the meltdown event bus. Each event carries a signed token and is validated before execution to prevent unauthorized operations.
 
 Always review your access logs and keep dependencies up to date. Security patches will continue to harden the platform over time.


### PR DESCRIPTION
## Summary
- document page hierarchy instead of PostType
- describe the page builder and lightweight UI in the CMS guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683d4ef3c9f08328bd966a1b7d3f6908