### PR TITLE
Rename default theme

### DIFF
--- a/BlogposterCMS/public/themes/default/theme.css
+++ b/BlogposterCMS/public/themes/default/theme.css
@@ -1,14 +1,101 @@
 :root {
-  --primary-color: #3b82f6;
+  /* Bootstrap-inspired color palette */
+  --primary-color: #0d6efd;
+  --secondary-color: #6c757d;
+  --success-color: #198754;
+  --danger-color: #dc3545;
+  --warning-color: #ffc107;
+  --info-color: #0dcaf0;
+  --light-color: #f8f9fa;
+  --dark-color: #212529;
+
   --font-family: 'Inter', sans-serif;
+  --background-color: #f9fafb;
 }
 
 body {
   font-family: var(--font-family);
+  background-color: var(--background-color);
 }
 
 /* Ensure widgets start at a readable size */
 .grid-stack-item {
   min-width: 120px;
   min-height: 80px;
+}
+
+/* --------------------------------------------------
+   Basic Header Layout
+   -------------------------------------------------- */
+header.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background-color: var(--primary-color);
+  color: #fff;
+}
+
+.navbar-brand {
+  font-size: 1.25rem;
+  text-decoration: none;
+  color: #fff;
+}
+
+.navbar-nav {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.navbar-nav a {
+  color: #fff;
+  text-decoration: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.navbar-nav a:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+/* --------------------------------------------------
+   Button Styles
+   -------------------------------------------------- */
+.btn {
+  display: inline-block;
+  font-weight: 400;
+  text-align: center;
+  user-select: none;
+  border: 1px solid transparent;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border-radius: 0.375rem;
+  transition: color 0.15s ease-in-out,
+              background-color 0.15s ease-in-out,
+              border-color 0.15s ease-in-out,
+              box-shadow 0.15s ease-in-out;
+}
+
+.btn-primary {
+  color: #fff;
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+}
+.btn-primary:hover {
+  background-color: #0b5ed7;
+  border-color: #0a58ca;
+}
+
+.btn-secondary {
+  color: #fff;
+  background-color: var(--secondary-color);
+  border-color: var(--secondary-color);
+}
+.btn-secondary:hover {
+  background-color: #5c636a;
+  border-color: #565e64;
 }

--- a/BlogposterCMS/public/themes/default/theme.json
+++ b/BlogposterCMS/public/themes/default/theme.json
@@ -1,6 +1,6 @@
 {
-  "name": "Default",
+  "name": "hello World",
   "version": "1.0.0",
   "author": "BlogposterCMS",
-  "description": "Default theme"
+  "description": "hello World theme"
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ BlogposterCMS is a modern, modular Node.js content management system built with 
    The `getPublicSetting` event exposes only whitelisted keys (such as `FIRST_INSTALL_DONE`) so the front-end can check installation state without elevated permissions. Alongside the `publicRegister` event, users can self-register while the system keeps admin-only settings private.
 
 10. **Theme Manager & Importer System**
-   Themes live under `public/themes`. The `themeManager` core module (located in `mother/modules/themeManager`) lists available themes via meltdown events, reading each theme's `theme.json` for metadata. The `importer` component has likewise moved to `mother/modules/importer` and exposes its importers through events. Both modules require a valid JWT and the usual `moduleName`/`moduleType` fields when invoked, ensuring only authorized code can list themes or run an import.
+Themes live under `public/themes`. The `themeManager` core module (located in `mother/modules/themeManager`) lists available themes via meltdown events, reading each theme's `theme.json` for metadata. The `importer` component has likewise moved to `mother/modules/importer` and exposes its importers through events. Both modules require a valid JWT and the usual `moduleName`/`moduleType` fields when invoked, ensuring only authorized code can list themes or run an import. The default bundled theme is **hello World**, featuring a Bootstrap-inspired header and button palette.
 
 *(More core features like a widget system, media management, and internationalization are also in progress, thanks to the modular design. As development continues, these will be fleshed out as separate modules… if we don’t get bored first.)*
 


### PR DESCRIPTION
## Summary
- rename the default theme to **hello World**
- add a background color variable to the public theme
- expand the theme with a Bootstrap-inspired header and button styling
- document the new `hello World` theme in the README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_683d619aff2c8328844b87e63dbc969e