### PR TITLE
Improve doc cross links

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,22 @@
+# Configuration Overview
+
+BlogposterCMS relies on environment variables for most of its settings. The
+`env.sample` file in the project root documents every supported option. Copy it
+to `.env` and adjust the values for your setup.
+
+Key variables to review:
+
+| Variable | Purpose |
+|----------|---------|
+| `PORT` | HTTP port used by the server. |
+| `JWT_SECRET` | Base secret for token signing. **Change this** before going live. |
+| `CONTENT_DB_TYPE` | Choose `postgres` or `mongodb`. |
+| `PG_*` / `MONGODB_URI` | Database connection settings. |
+| `AUTH_MODULE_INTERNAL_SECRET` | Shared secret used by the auth module when issuing tokens. |
+| `TOKEN_SALT_HIGH` etc. | Additional salts used to derive secrets per trust level. |
+| `ENABLE_API` | Enables a lightweight REST API on `API_PORT` when set to `true`. |
+| `ALLOW_REGISTRATION` | If `true`, users may self-register via the public event. |
+
+For advanced deployments you can override defaults by creating
+`config/runtime.local.js` or `config/security.local.js`. These files are
+ignored by Git so your private values remain secret.

--- a/docs/developer_quickstart.md
+++ b/docs/developer_quickstart.md
@@ -1,0 +1,41 @@
+# Developer Quickstart
+
+This page summarises the steps to spin up BlogposterCMS for local development and run the included tests. Make sure you have Node.js installed.
+First follow the [Installation](installation.md) guide if you have not yet set up the project.
+
+1. **Clone and install**
+   ```bash
+   git clone <repo-url>
+   cd BlogposterCMS
+   npm install
+   ```
+
+2. **Create `.env`**
+   ```bash
+   cp env.sample .env
+   # edit .env and replace the placeholder secrets
+   ```
+   Use strong random values for `JWT_SECRET` and the various *_SALT variables.
+   Leaving the defaults (e.g. `default_secret`) is insecure in production.
+
+3. **Build assets and start the server**
+   ```bash
+   npm run build
+   npm start
+   ```
+   The server listens on the port configured in `.env` (default `3000`). Visit
+   `http://localhost:3000/` to access the CMS.
+
+4. **Run tests**
+   ```bash
+   npm test
+   ```
+   The test script executes a series of Node-based integration tests located in
+   the `tests/` directory. Ensure the server is **not** already running when you
+   run them.
+
+5. **Coding conventions**
+   - Keep modules self-contained and communicate only via meltdown events.
+   - Check `npm audit` regularly to catch vulnerable dependencies.
+   - We recommend using `eslint` (not included by default) to maintain
+     consistent style.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,5 +8,9 @@ Welcome to the documentation folder for **BlogposterCMS**. This section provides
 - [Architecture Overview](architecture.md)
 - [Security Notes](security.md)
 - [CMS Usage Guide](guide.md)
+- [Developer Quickstart](developer_quickstart.md)
+- [Configuration Overview](configuration.md)
+- [Meltdown Event Bus](meltdown_event_bus.md)
+- [Notification System](notification_system.md)
 
 For the full project overview and sarcasm-filled introduction, see the main [README](../README.md).

--- a/docs/meltdown_event_bus.md
+++ b/docs/meltdown_event_bus.md
@@ -1,0 +1,37 @@
+# Meltdown Event Bus
+
+BlogposterCMS modules communicate exclusively via the **meltdown event bus**. It
+is powered by the `motherEmitter` which verifies JSON Web Tokens on every event
+before dispatching them. When a module misbehaves, the emitter can trigger a
+*local meltdown* for that module so it can no longer execute actions.
+
+## Event Lifecycle
+
+1. A module emits an event with a payload containing its `moduleName`,
+   `moduleType` and a signed JWT.
+2. `motherEmitter` checks whether the module is currently in meltdown. If so,
+   the event is ignored.
+3. If the event is public (such as `issuePublicToken`) it bypasses JWT checks
+   but still logs the call.
+4. Non‑public events require a valid JWT. The emitter decodes the token,
+   combines the secret with the correct salt depending on `trustLevel` and then
+   verifies it.
+5. If verification succeeds, the event is dispatched to all listeners. Any
+   thrown error triggers a meltdown for that module, removing all of its
+   listeners.
+
+## Why Meltdown?
+
+The goal is **containment**. If a community module crashes or tries to bypass
+permissions, only that module is disabled. The rest of the CMS keeps running
+and administrators are notified via the notification system. This approach helps
+maintain security when running untrusted code.
+
+## Writing Safe Event Handlers
+
+- Validate payload fields before performing actions.
+- Return errors through the callback so the emitter can react properly.
+- Avoid long synchronous tasks that block the event loop; they may cause
+  timeouts and trigger a meltdown unintentionally.
+
+For an overview of how modules use this bus, see [Module Architecture](modules.md).

--- a/docs/modules/notificationManager.md
+++ b/docs/modules/notificationManager.md
@@ -13,3 +13,5 @@ Dispatches system notifications to configured integrations such as email or web 
 - This module does not expose meltdown events directly. Instead it listens on `notificationEmitter` for `notify` events.
 
 Each integration can perform its own security checks before sending data externally.
+
+See the high level [Notification System](../notification_system.md) guide for configuration examples.

--- a/docs/notification_system.md
+++ b/docs/notification_system.md
@@ -1,0 +1,42 @@
+# Notification System
+
+The `notificationManager` core module provides a simple pluggable way to deliver
+system notifications. Integrations can write to log files, send emails or post
+to chat services such as Slack.
+
+## Registry and Integrations
+
+Integrations live in `mother/modules/notificationManager/integrations`. Each
+integration exports an object with an `integrationName` and an `initialize`
+method. When the CMS starts, the manager loads the `integrationsRegistry.json`
+file to determine which integrations are active and passes their stored config to
+`initialize`.
+
+Example registry entry:
+```json
+{
+  "SMTP": {
+    "active": false,
+    "config": {
+      "host": "smtp.myserver.com",
+      "port": 587,
+      "user": "myuser",
+      "pass": "mypassword"
+    }
+  }
+}
+```
+Replace these placeholder credentials with real values in a deployment-specific
+registry file that is **not** committed to version control.
+
+## Usage
+
+Other modules emit `notify` events via `notificationEmitter` with a payload
+containing a `notificationType`, `priority` and free-form `message`. All active
+integrations receive the payload. If an integration throws an error during
+notification delivery, it is logged but the CMS continues running.
+
+This system ensures important events (such as module meltdowns) can alert
+administrators via the channels they prefer.
+
+For a deeper look at the implementation, see the [Notification Manager](modules/notificationManager.md) documentation.


### PR DESCRIPTION
## Summary
- link Notification System doc to Notification Manager module
- cross-link Notification Manager back to Notification System
- reference Module Architecture from the Meltdown Event Bus guide
- point Developer Quickstart readers to the Installation guide first

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683d6ce3da3483289c7e4b933ab09846