### PR TITLE
Improve login strategy docs and index

### DIFF
--- a/docs/how_login_strategies_work.md
+++ b/docs/how_login_strategies_work.md
@@ -1,0 +1,67 @@
+# Adding OAuth and Custom Login Strategies
+
+This guide explains how to add new login strategies for the **Auth Module**. BlogposterCMS already provides `adminLocal`, `google` and `facebook` strategies. Additional strategies can be loaded automatically when placed under `mother/modules/auth/strategies`.
+
+## Requirements
+- The Auth Module must run as a core module.
+- `JWT_SECRET` and `AUTH_MODULE_INTERNAL_SECRET` must be configured.
+- Keep any OAuth client IDs or secrets outside of version control, preferably in environment variables or the settings store.
+
+## Creating a Strategy
+1. Create a new file under `mother/modules/auth/strategies/`.
+2. Export an `initialize({ motherEmitter, JWT_SECRET, authModuleSecret })` function.
+3. Inside the function emit `registerLoginStrategy` with `skipJWT: true`, `moduleType: 'core'`, `moduleName: 'auth'`, the `authModuleSecret`, a `strategyName`, a short `description` and a `loginFunction`.
+4. The `loginFunction` is called during `loginWithStrategy`. It should validate the third‑party token, find or create the local user via meltdown events and finally emit `finalizeUserLogin` to receive the full user object.
+
+Example skeleton:
+```js
+module.exports = {
+  initialize({ motherEmitter, JWT_SECRET, authModuleSecret }) {
+    motherEmitter.emit(
+      'registerLoginStrategy',
+      {
+        skipJWT: true,
+        moduleType: 'core',
+        moduleName: 'auth',
+        authModuleSecret,
+        strategyName: 'myProvider',
+        description: 'My OAuth login',
+        loginFunction: async (token, callback) => {
+          try {
+            // 1) Validate `token` with the provider's API
+            // 2) Find or create the local user using meltdown events
+            // 3) Call `callback(null, finalUserObj)` when done
+          } catch (err) {
+            callback(err);
+          }
+        }
+      },
+      err => {
+        if (err) console.error('[MY STRATEGY] Failed to register', err);
+      }
+    );
+  }
+};
+```
+
+## Security Notes
+- Always verify tokens with the OAuth provider before trusting them.
+- Never commit OAuth secrets to the repository.
+- Disable a compromised strategy with the `setLoginStrategyEnabled` event.
+
+## Enabling or Disabling Strategies
+Use `setLoginStrategyEnabled` with a core JWT to toggle a strategy:
+```js
+motherEmitter.emit(
+  'setLoginStrategyEnabled',
+  {
+    jwt,
+    moduleName: 'auth',
+    moduleType: 'core',
+    strategyName: 'google',
+    enabled: true
+  },
+  callback
+);
+```
+List current strategies with `listActiveLoginStrategies`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,5 +12,16 @@ Welcome to the documentation folder for **BlogposterCMS**. This section provides
 - [Configuration Overview](configuration.md)
 - [Meltdown Event Bus](meltdown_event_bus.md)
 - [Notification System](notification_system.md)
+- [How Login Strategies Work](how_login_strategies_work.md)
 
 For the full project overview and sarcasm-filled introduction, see the main [README](../README.md).
+
+## Q&A
+
+**Where do I configure login strategies?**
+
+Login strategies are handled by the [Auth Module](modules/auth.md). To create your own or integrate OAuth providers, see [How Login Strategies Work](how_login_strategies_work.md).
+
+**Do I need OAuth to use BlogposterCMS?**
+
+No. The built-in `adminLocal` strategy provides username/password authentication. OAuth strategies are optional and can be enabled or disabled individually.

--- a/docs/modules/auth.md
+++ b/docs/modules/auth.md
@@ -1,19 +1,37 @@
 # Auth Module
 
-The authentication module validates credentials and issues JWTs for other modules. It must be loaded as a core module so it can register login strategies and manage tokens securely.
+The Auth Module validates credentials and issues JWTs for the rest of the system. It **must** run as a core module so it can manage login strategies and sign tokens securely.
 
 ## Startup
 - Loaded during server boot by the core loader.
 - Requires `JWT_SECRET` and `AUTH_MODULE_INTERNAL_SECRET` in the environment.
+- Automatically loads any strategy files under `mother/modules/auth/strategies`.
 
 ## Purpose
-- Provides login strategies (local, OAuth etc.).
-- Verifies tokens for the event bus.
+- Provides login strategies (local and OAuth) that modules or the public API can use.
+- Issues and validates tokens for modules and users.
+- Stores refresh tokens in the database and supports token revocation.
+- Offers helpers to check or extend token lifetimes.
 
 ## Listened Events
 - `listActiveLoginStrategies`
 - `setLoginStrategyEnabled`
 - `registerLoginStrategy`
 - `loginWithStrategy`
+- `issueModuleToken`
+- `issueUserToken`
+- `issuePublicToken`
+- `ensurePublicToken`
+- `validateToken`
+- `revokeToken`
+- `revokeAllTokensForUser`
+- `issueRefreshToken`
+- `refreshAccessToken`
+- `revokeRefreshToken`
+- `setModuleTokenExpiry`
+- `setUserTokenExpiry`
 
 All payloads must include a valid JWT and the correct `moduleName`/`moduleType`. Invalid calls are rejected.
+
+## Adding Login Strategies
+See [Adding OAuth and Custom Login Strategies](../how_login_strategies_work.md) for a step‑by‑step guide on implementing new strategies and keeping secrets safe.


### PR DESCRIPTION
## Summary
- rename `login_strategies.md` to `how_login_strategies_work.md`
- update Auth module docs to link to the new file
- add new "How Login Strategies Work" link and Q&A section in `docs/index.md`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683da94933808328acf33d550eb1549e