### PR TITLE
Fix cache path for Node setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: "20"
           cache: 'npm'
+          cache-dependency-path: BlogposterCMS/package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Build


### PR DESCRIPTION
## Summary
- fix Node.js setup step to locate dependency lock file in BlogposterCMS

## Testing
- `npm test`
- `npm run build` *(fails: missing assets)*

------
https://chatgpt.com/codex/tasks/task_e_683db2235db48328846f0970c8cbbe9b