### PR TITLE
Fix relative imports for pageRenderer build

### DIFF
--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -1,7 +1,7 @@
 // public/assets/js/pageRenderer.js
 
-import { fetchPartial } from '/assets/plainspace/admin/fetchPartial.js';
-import { initBuilder } from '/assets/plainspace/admin/builderRenderer.js';
+import { fetchPartial } from '../plainspace/admin/fetchPartial.js';
+import { initBuilder } from '../plainspace/admin/builderRenderer.js';
 
 // Default rows for admin widgets (~50px with 5px grid cells)
 // Temporary patch: double the default height for larger widgets


### PR DESCRIPTION
## Summary
- fix absolute imports in `pageRenderer.js` that broke webpack

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683db802a00083288473e1d834064a7e