### PR TITLE
Replace vm2 with custom vm sandbox

### DIFF
--- a/docs/modules/moduleLoader.md
+++ b/docs/modules/moduleLoader.md
@@ -1,6 +1,6 @@
 # Module Loader
 
-Loads optional community modules from the top-level `modules/` directory. Each module is sandboxed during a health check to prevent crashes or unsafe behaviour.
+Loads optional community modules from the top-level `modules/` directory. Each module is sandboxed during a health check to prevent crashes or unsafe behaviour. The sandbox uses Node's `vm` module and only exposes `path` and `fs` as allowed dependencies.
 
 ## Startup
 - Core module executed after the initial core modules are ready.

--- a/docs/security.md
+++ b/docs/security.md
@@ -6,7 +6,7 @@ BlogposterCMS was designed with multiple layers of security in mind. While no sy
 - **HTTPS** – When running in production, place the app behind HTTPS and set `NODE_ENV=production` to enable secure cookies and redirects.
 - **Rate limiting** – The configuration in `config/security.js` defines limits for login attempts to slow down brute-force attacks. Adjust these values according to your needs.
 - **CSRF protection** – Admin routes use CSRF tokens to prevent cross-site request forgery. Clients must include the token when authenticating or performing sensitive actions.
-- **Module sandboxing** – Optional modules are loaded inside a sandbox. Faulty or malicious modules are deactivated automatically when health checks fail.
+- **Module sandboxing** – Optional modules run inside a minimal sandbox built with Node's `vm` module. Only `path` and `fs` can be required and network access is blocked. Faulty or malicious modules are deactivated automatically when health checks fail.
 - **JWT event bus** – All internal actions pass through the meltdown event bus. Each event carries a signed token and is validated before execution to prevent unauthorized operations.
 
 - **HTTP security headers** – Configure a Content-Security-Policy and other headers (using middleware such as `helmet`) to protect against common attacks like XSS and clickjacking.


### PR DESCRIPTION
## Summary
- replace vm2 with a small vm-based sandbox in `moduleLoader`
- explain vm-based sandbox in docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683dbc48962483288141f0a4b0c14e03