### PR TITLE
Implement API rate limiting

### DIFF
--- a/BlogposterCMS/config/security.js
+++ b/BlogposterCMS/config/security.js
@@ -25,12 +25,24 @@ const rate = {
     /* Header style (see express‑rate‑limit docs) */
     standardHeaders : true,
     legacyHeaders   : false
+  },
+  /* General API / meltdown limiter */
+  api : {
+    windowMs        : 15 * 60 * 1000,      // 15 min
+    max             : 100,                 // sensible default
+    message         : { error: 'Too many requests – try again later.' },
+    standardHeaders : true,
+    legacyHeaders   : false
   }
 };
 
 /* .env overrides – operators can tune without touching code */
 rate.login.windowMs = Number(env.LOGIN_LIMIT_WINDOW_MS ?? rate.login.windowMs);
 rate.login.max      = Number(env.LOGIN_LIMIT_MAX       ?? rate.login.max);
+rate.api.windowMs   = Number(env.API_RATE_LIMIT_WINDOW
+  ? Number(env.API_RATE_LIMIT_WINDOW) * 60 * 1000
+  : rate.api.windowMs);
+rate.api.max        = Number(env.API_RATE_LIMIT_MAX ?? rate.api.max);
 
 /*─────────────────────────────────────────────────────────────────────*
  *  #2  CSRF CONFIG

--- a/BlogposterCMS/mother/utils/rateLimiters.js
+++ b/BlogposterCMS/mother/utils/rateLimiters.js
@@ -1,0 +1,20 @@
+const rateLimit = require('express-rate-limit');
+const { rate } = require('../../config/security');
+
+const apiLimiter = rateLimit({
+  windowMs: rate.api.windowMs,
+  max: rate.api.max,
+  message: rate.api.message,
+  standardHeaders: rate.api.standardHeaders,
+  legacyHeaders: rate.api.legacyHeaders
+});
+
+const loginLimiter = rateLimit({
+  windowMs: rate.login.windowMs,
+  max: rate.login.max,
+  message: rate.login.message,
+  standardHeaders: rate.login.standardHeaders,
+  legacyHeaders: rate.login.legacyHeaders
+});
+
+module.exports = { apiLimiter, loginLimiter };

--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "start": "node app.js",
         "dev": "nodemon app.js",
-        "test": "node tests/setAsStart.test.js && node tests/updatePage.test.js && node tests/notificationManager.test.js && node tests/publicEvents.test.js && node tests/themeImporter.test.js && node tests/cookieSanitization.test.js",
+        "test": "node tests/setAsStart.test.js && node tests/updatePage.test.js && node tests/notificationManager.test.js && node tests/publicEvents.test.js && node tests/themeImporter.test.js && node tests/cookieSanitization.test.js && node tests/rateLimiter.test.js",
         "build": "webpack --mode production"
     },
     "dependencies": {

--- a/BlogposterCMS/tests/rateLimiter.test.js
+++ b/BlogposterCMS/tests/rateLimiter.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+function testMiddlewareUsage() {
+  const appJs = fs.readFileSync(path.join(__dirname, '..', 'app.js'), 'utf8');
+  assert(
+    appJs.includes("app.post('/api/meltdown', apiLimiter"),
+    'Missing apiLimiter on /api/meltdown route'
+  );
+  assert(
+    appJs.includes("app.post('/admin/api/login', loginLimiter"),
+    'Missing loginLimiter on /admin/api/login route'
+  );
+}
+
+(async () => {
+  try {
+    testMiddlewareUsage();
+    console.log('rate limiter tests passed');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add express-rate-limit middleware
- limit POST `/api/meltdown` and `/admin/api/login`
- cover middleware presence with a small test

## Testing
- `npm test --prefix BlogposterCMS`


------
https://chatgpt.com/codex/tasks/task_e_683dd51317948328a36682c3fcb53e46