### PR TITLE
Remove insecure default secrets

### DIFF
--- a/BlogposterCMS/mother/emitters/motherEmitter.js
+++ b/BlogposterCMS/mother/emitters/motherEmitter.js
@@ -15,8 +15,8 @@ const jwt = require('jsonwebtoken');
 
 const notificationEmitter = require('./notificationEmitter');
 
-// For demonstration
-const JWT_SECRET         = process.env.JWT_SECRET || 'default_secret';
+// Secrets must be provided via environment variables
+const JWT_SECRET         = process.env.JWT_SECRET;
 const TOKEN_SALT_HIGH    = process.env.TOKEN_SALT_HIGH   || '';
 const TOKEN_SALT_MEDIUM  = process.env.TOKEN_SALT_MEDIUM || '';
 const TOKEN_SALT_LOW     = process.env.TOKEN_SALT_LOW    || '';

--- a/BlogposterCMS/mother/emitters/notificationEmitter.js
+++ b/BlogposterCMS/mother/emitters/notificationEmitter.js
@@ -12,8 +12,8 @@ const EventEmitter = require('events');
 const jwt = require('jsonwebtoken');
 
 // Optional: Falls du JWT für Notifications absichern willst
-const NOTIFICATION_JWT_SECRET = process.env.NOTIFICATION_JWT_SECRET || 'some_secret';
-const NOTIFICATION_SALT = process.env.NOTIFICATION_SALT || '_notify_salt';
+const NOTIFICATION_JWT_SECRET = process.env.NOTIFICATION_JWT_SECRET;
+const NOTIFICATION_SALT = process.env.NOTIFICATION_SALT;
 
 // Mögliche Notification-Typen/Gruppen.
 // Erweitert um "info" und "debug" damit Module diese Typen verwenden können,

--- a/docs/developer_quickstart.md
+++ b/docs/developer_quickstart.md
@@ -15,8 +15,9 @@ First follow the [Installation](installation.md) guide if you have not yet set u
    cp env.sample .env
    # edit .env and replace the placeholder secrets
    ```
-   Use strong random values for `JWT_SECRET` and the various *_SALT variables.
-   Leaving the defaults (e.g. `default_secret`) is insecure in production.
+  Use strong random values for `JWT_SECRET` and the various *_SALT variables.
+  The application no longer provides fallback secrets, so missing values will
+  cause startup errors.
 
 3. **Build assets and start the server**
    ```bash


### PR DESCRIPTION
## Summary
- drop fallback secrets from motherEmitter and notificationEmitter
- update the developer quickstart docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e90fc5ed0832895acf8001b4e3292