### PR TITLE
Fix module registry log format

### DIFF
--- a/BlogposterCMS/mother/modules/moduleLoader/moduleRegistryService.js
+++ b/BlogposterCMS/mother/modules/moduleLoader/moduleRegistryService.js
@@ -265,13 +265,17 @@ function deactivateModule(motherEmitter, jwt, moduleName, errMsg) {
           updated_at : new Date()
         }
       },
-      (err) => {
-        if (err) {
-          console.error(`[MODULE LOADER] Error deactivating module ${moduleName}:`, err.message);
-          return reject(err);
+        (err) => {
+          if (err) {
+            console.error(
+              `[MODULE LOADER] Error deactivating module %s: %s`,
+              moduleName,
+              err.message
+            );
+            return reject(err);
+          }
+          resolve();
         }
-        resolve();
-      }
     );
   });
 }


### PR DESCRIPTION
## Summary
- sanitize module deactivation log to avoid tainted format string

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_683e9a10cd208328a149139a8e40d9eb