### PR TITLE
Fix module registry log format

### DIFF
--- a/BlogposterCMS/mother/modules/moduleLoader/moduleRegistryService.js
+++ b/BlogposterCMS/mother/modules/moduleLoader/moduleRegistryService.js
@@ -240,7 +240,11 @@ function updateModuleLastError(motherEmitter, jwt, moduleName, lastError) {
       },
       (err) => {
         if (err) {
-          console.error(`[MODULE LOADER] Error updating last_error for ${moduleName}:`, err.message);
+          console.error(
+            `[MODULE LOADER] Error updating last_error for %s: %s`,
+            moduleName,
+            err.message
+          );
           return reject(err);
         }
         resolve();
@@ -265,13 +269,17 @@ function deactivateModule(motherEmitter, jwt, moduleName, errMsg) {
           updated_at : new Date()
         }
       },
-      (err) => {
-        if (err) {
-          console.error(`[MODULE LOADER] Error deactivating module ${moduleName}:`, err.message);
-          return reject(err);
+        (err) => {
+          if (err) {
+            console.error(
+              `[MODULE LOADER] Error deactivating module %s: %s`,
+              moduleName,
+              err.message
+            );
+            return reject(err);
+          }
+          resolve();
         }
-        resolve();
-      }
     );
   });
 }


### PR DESCRIPTION
## Summary
- sanitize module update log to avoid tainted format string

## Testing
- `npm test --prefix BlogposterCMS`


------
https://chatgpt.com/codex/tasks/task_e_683e9a10cd208328a149139a8e40d9eb