### PR TITLE
Fix path injection by sanitizing module names

### DIFF
--- a/BlogposterCMS/mother/modules/moduleLoader/moduleRegistryEvents.js
+++ b/BlogposterCMS/mother/modules/moduleLoader/moduleRegistryEvents.js
@@ -16,6 +16,7 @@ const {
   updateModuleLastError,
   deactivateModule
 } = require('./moduleRegistryService');
+const { sanitizeModuleName } = require('../../utils/moduleUtils');
 
 function initModuleRegistryAdminEvents(motherEmitter, app) {
   // meltdown => 'activateModuleInRegistry'
@@ -106,8 +107,13 @@ function initModuleRegistryAdminEvents(motherEmitter, app) {
 async function attemptSingleLoad(moduleName, motherEmitter, app, jwt) {
   // attempt to require & initialize the module
   try {
+    moduleName = sanitizeModuleName(moduleName);
     const modulesDir = path.resolve(__dirname, '../../../modules');
-    const indexJs = path.join(modulesDir, moduleName, 'index.js');
+    const modulePath = path.resolve(modulesDir, moduleName);
+    if (!modulePath.startsWith(modulesDir + path.sep)) {
+      throw new Error('Invalid module name path');
+    }
+    const indexJs = path.join(modulePath, 'index.js');
 
     if (!fs.existsSync(indexJs)) {
       console.warn(`[REGISTRY EVENTS] No index.js => ${moduleName}`);

--- a/BlogposterCMS/mother/utils/moduleUtils.js
+++ b/BlogposterCMS/mother/utils/moduleUtils.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function sanitizeModuleName(name) {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new Error('Invalid module name');
+  }
+  if (!/^[A-Za-z0-9_-]+$/.test(name)) {
+    throw new Error('Invalid module name');
+  }
+  return name;
+}
+
+module.exports = { sanitizeModuleName };

--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "start": "node app.js",
         "dev": "nodemon app.js",
-        "test": "node tests/setAsStart.test.js && node tests/updatePage.test.js && node tests/notificationManager.test.js && node tests/publicEvents.test.js && node tests/themeImporter.test.js && node tests/cookieSanitization.test.js && node tests/rateLimiter.test.js",
+        "test": "node tests/setAsStart.test.js && node tests/updatePage.test.js && node tests/notificationManager.test.js && node tests/publicEvents.test.js && node tests/themeImporter.test.js && node tests/cookieSanitization.test.js && node tests/rateLimiter.test.js && node tests/moduleNameSanitization.test.js",
         "build": "webpack --mode production"
     },
     "dependencies": {

--- a/BlogposterCMS/tests/moduleNameSanitization.test.js
+++ b/BlogposterCMS/tests/moduleNameSanitization.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { sanitizeModuleName } = require('../mother/utils/moduleUtils');
+
+function testValid() {
+  assert.doesNotThrow(() => sanitizeModuleName('example_module-1'));
+}
+
+function testInvalid() {
+  assert.throws(() => sanitizeModuleName('../evil'), /Invalid module name/);
+  assert.throws(() => sanitizeModuleName('bad/name'), /Invalid module name/);
+}
+
+(async () => {
+  try {
+    testValid();
+    testInvalid();
+    console.log('module name sanitization tests passed');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- validate module names with `sanitizeModuleName`
- ensure module loader checks resulting path
- add tests for module name sanitization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ea9b74af88328a84bfcbc44334a92