### PR TITLE
Fix prototype pollution in permission utils

### DIFF
--- a/BlogposterCMS/mother/modules/userManagement/permissionUtils.js
+++ b/BlogposterCMS/mother/modules/userManagement/permissionUtils.js
@@ -9,16 +9,22 @@
  */
 
 function deepMerge(target, source) {
-  for (const key in source) {
-    if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
-      if (!target[key]) {
+  if (!source || typeof source !== 'object') return target;
+  for (const key of Object.keys(source)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue; // prevent prototype pollution
+    }
+    const value = source[key];
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      if (!Object.prototype.hasOwnProperty.call(target, key) || typeof target[key] !== 'object') {
         target[key] = {};
       }
-      deepMerge(target[key], source[key]);
+      deepMerge(target[key], value);
     } else {
-      target[key] = source[key];
+      target[key] = value;
     }
   }
+  return target;
 }
 
 /**

--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "start": "node app.js",
         "dev": "nodemon app.js",
-        "test": "node tests/setAsStart.test.js && node tests/updatePage.test.js && node tests/notificationManager.test.js && node tests/publicEvents.test.js && node tests/themeImporter.test.js && node tests/cookieSanitization.test.js && node tests/rateLimiter.test.js && node tests/moduleNameSanitization.test.js",
+        "test": "node tests/setAsStart.test.js && node tests/updatePage.test.js && node tests/notificationManager.test.js && node tests/publicEvents.test.js && node tests/themeImporter.test.js && node tests/cookieSanitization.test.js && node tests/rateLimiter.test.js && node tests/moduleNameSanitization.test.js && node tests/permissionUtils.test.js",
         "build": "webpack --mode production"
     },
     "dependencies": {

--- a/BlogposterCMS/tests/permissionUtils.test.js
+++ b/BlogposterCMS/tests/permissionUtils.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const { deepMerge } = require('../mother/modules/userManagement/permissionUtils');
+
+function testPrototypePollution() {
+  const target = {};
+  const source = JSON.parse('{ "__proto__": { "polluted": true } }');
+  deepMerge(target, source);
+  assert.strictEqual({}.polluted, undefined, 'Object prototype was polluted');
+  assert.strictEqual(target.polluted, undefined, 'Target object was polluted');
+}
+
+function testRegularMerge() {
+  const target = { a: 1, b: { c: 3 } };
+  deepMerge(target, { b: { d: 4 }, e: 5 });
+  assert.strictEqual(target.a, 1);
+  assert.strictEqual(target.b.c, 3);
+  assert.strictEqual(target.b.d, 4);
+  assert.strictEqual(target.e, 5);
+}
+
+(async () => {
+  try {
+    testPrototypePollution();
+    testRegularMerge();
+    console.log('permission utils tests passed');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- protect `deepMerge` from prototype pollution
- add tests for `deepMerge` security

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683eb1254d2c8328a317caa293d37ebd