### PR TITLE
Fix prototype pollution risk in auth module

### DIFF
--- a/BlogposterCMS/mother/modules/auth/index.js
+++ b/BlogposterCMS/mother/modules/auth/index.js
@@ -67,6 +67,10 @@ module.exports = {
       if (!strategyName) {
         return callback(new Error('No strategyName specified.'));
       }
+      const disallowed = ['__proto__', 'prototype', 'constructor'];
+      if (disallowed.includes(strategyName)) {
+        return callback(new Error('Invalid strategy name.'));
+      }
       if (!Object.prototype.hasOwnProperty.call(global.loginStrategies, strategyName)) {
         return callback(new Error(`Strategy "${strategyName}" not found.`));
       }


### PR DESCRIPTION
## Summary
- validate strategy names in `setLoginStrategyEnabled`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683eb5ae26f0832881593c78323ea58d