### PR TITLE
Add SQLite support

### DIFF
--- a/BlogposterCMS/env.sample
+++ b/BlogposterCMS/env.sample
@@ -14,11 +14,15 @@ PG_ADMIN_USER=postgres_admin_user
 PG_ADMIN_PASSWORD=postgres_admin_password
 PG_ADMIN_DB=postgres_admin_db
 
-# Choose database type ('postgres' or 'mongodb')
+# Choose database type ('postgres', 'mongodb' or 'sqlite')
 CONTENT_DB_TYPE=postgres
 
 # MongoDB Connection URI
 MONGODB_URI=mongodb://username:password@localhost:27017/admin
+
+# SQLite storage location (only used when CONTENT_DB_TYPE=sqlite)
+SQLITE_STORAGE=./data
+SQLITE_MAIN_FILE=cms.sqlite
 
 # Internal Auth Token (module authentication)
 AUTH_MODULE_INTERNAL_SECRET=YOUR_AUTH_MODULE_SECRET

--- a/BlogposterCMS/mother/modules/databaseManager/config/databaseConfig.js
+++ b/BlogposterCMS/mother/modules/databaseManager/config/databaseConfig.js
@@ -33,5 +33,9 @@ module.exports = {
   mongoAdminPassword: process.env.MONGO_ADMIN_PASSWORD || 'adminpass',
   mongoHost:          process.env.MONGO_HOST || 'localhost',
   mongoPort:          process.env.MONGO_PORT || '27017',
-  mongoUri:           process.env.MONGODB_URI || null
+  mongoUri:           process.env.MONGODB_URI || null,
+
+  // SQLite
+  sqliteStorage:      process.env.SQLITE_STORAGE || './data',
+  sqliteMainFile:     process.env.SQLITE_MAIN_FILE || 'cms.sqlite'
 };

--- a/BlogposterCMS/mother/modules/databaseManager/engines/engineFactory.js
+++ b/BlogposterCMS/mother/modules/databaseManager/engines/engineFactory.js
@@ -4,11 +4,13 @@
 const { getDbType } = require('../helpers/dbTypeHelpers');
 const postgresEngine = require('./postgresEngine');
 const mongoEngine = require('./mongoEngine');
+const sqliteEngine = require('./sqliteEngine');
 
 function getEngine() {
   const type = getDbType();
   if (type === 'postgres') return postgresEngine;
   if (type === 'mongodb') return mongoEngine;
+  if (type === 'sqlite') return sqliteEngine;
   throw new Error(`[engineFactory] Unknown DB type=${type}`);
 }
 

--- a/BlogposterCMS/mother/modules/databaseManager/engines/sqliteEngine.js
+++ b/BlogposterCMS/mother/modules/databaseManager/engines/sqliteEngine.js
@@ -1,0 +1,63 @@
+/**
+ * mother/modules/databaseManager/engines/sqliteEngine.js
+ *
+ * Provides minimal SQLite support for BlogposterCMS.
+ * Creates database files per module and performs basic SQL operations.
+ */
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+const {
+  sqliteStorage,
+  sqliteMainFile
+} = require('../config/databaseConfig');
+const { sanitizeModuleName } = require('../../utils/moduleUtils');
+const notificationEmitter = require('../../../emitters/notificationEmitter');
+
+function getDbPath(moduleName, isOwnDb) {
+  const safeName = sanitizeModuleName(moduleName).toLowerCase();
+  const file = isOwnDb ? `${safeName}.sqlite` : sqliteMainFile;
+  return path.resolve(sqliteStorage, file);
+}
+
+function ensureDbFile(dbPath) {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  if (!fs.existsSync(dbPath)) {
+    fs.closeSync(fs.openSync(dbPath, 'w'));
+  }
+}
+
+async function createOrFixSqliteDatabaseForModule(moduleName, isOwnDb) {
+  const dbPath = getDbPath(moduleName, isOwnDb);
+  ensureDbFile(dbPath);
+  notificationEmitter.notify({
+    moduleName: 'databaseManager',
+    notificationType: 'info',
+    priority: 'info',
+    message: `[SQLiteEngine] Using database at ${dbPath}`
+  });
+  return { dbPath };
+}
+
+function performSqliteOperation(moduleName, operation, params = [], isOwnDb) {
+  return new Promise((resolve, reject) => {
+    const dbPath = getDbPath(moduleName, isOwnDb);
+    const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE, err => {
+      if (err) {
+        return reject(err);
+      }
+    });
+    db.all(operation, params, (err, rows) => {
+      db.close();
+      if (err) {
+        return reject(err);
+      }
+      resolve({ rows });
+    });
+  });
+}
+
+module.exports = {
+  createOrFixSqliteDatabaseForModule,
+  performSqliteOperation
+};

--- a/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/createDatabaseEvent.js
+++ b/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/createDatabaseEvent.js
@@ -7,6 +7,7 @@ const { getEngine } = require('../engines/engineFactory');
 const { moduleHasOwnDb } = require('../helpers/dbTypeHelpers');
 const { createOrFixSchemaInMainDb } = require('../engines/postgresEngine');
 const { createMongoDatabase } = require('../engines/mongoEngine');
+const { createOrFixSqliteDatabaseForModule } = require('../engines/sqliteEngine');
 const { getDbType } = require('../helpers/dbTypeHelpers');
 const { onceCallback } = require('../../../emitters/motherEmitter');
 
@@ -67,6 +68,15 @@ function registerCreateDatabaseEvent(motherEmitter) {
           message: `Successfully created/fixed MongoDB for "${moduleName}".`
         });
         callback(null, { success: true, type: 'mongodb' });
+      } else if (dbType === 'sqlite') {
+        await createOrFixSqliteDatabaseForModule(moduleName, isOwnDb);
+        notificationEmitter.notify({
+          moduleName: 'databaseManager',
+          notificationType: 'info',
+          priority: 'info',
+          message: `Successfully prepared SQLite DB for "${moduleName}".`
+        });
+        callback(null, { success: true, type: 'sqlite' });
       } else {
         throw new Error(`Unsupported DB type: ${dbType}`);
       }

--- a/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/performDbOperationEvent.js
+++ b/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/performDbOperationEvent.js
@@ -64,8 +64,9 @@ function registerPerformDbOperationEvent(motherEmitter) {
       if (dbType === 'postgres') {
         result = await engine.performPostgresOperation(moduleName, operation, params, isOwnDb);
       } else if (dbType === 'mongodb') {
-        // Assuming performMongoOperation doesn't need isOwnDb logic for this example
-        result = await engine.performMongoOperation(moduleName, operation, params); 
+        result = await engine.performMongoOperation(moduleName, operation, params);
+      } else if (dbType === 'sqlite') {
+        result = await engine.performSqliteOperation(moduleName, operation, params, isOwnDb);
       } else {
         // Handle unsupported database types
         throw new Error(`Unsupported DB type configured: ${dbType}`);

--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/handlePlaceholder.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/handlePlaceholder.js
@@ -5,6 +5,7 @@ const builtinPlaceholders = require('./builtinPlaceholders');
 const { getCustomPlaceholder } = require('./placeholderRegistry');
 const { handleBuiltInPlaceholderPostgres } = require('./postgresPlaceholders');
 const { handleBuiltInPlaceholderMongo } = require('./mongoPlaceholders');
+const { handleBuiltInPlaceholderSqlite } = require('./sqlitePlaceholders');
 
 // NEW: typed notification emitter
 const notificationEmitter = require('../../../emitters/notificationEmitter');
@@ -28,6 +29,8 @@ async function handlePlaceholder(dbClient, dbType, operation, params = []) {
       return handleBuiltInPlaceholderPostgres(dbClient, operation, params);
     } else if (dbType === 'mongodb') {
       return handleBuiltInPlaceholderMongo(dbClient, operation, params);
+    } else if (dbType === 'sqlite') {
+      return handleBuiltInPlaceholderSqlite(dbClient, operation, params);
     } else {
       notificationEmitter.notify({
         moduleName: 'databaseManager',

--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/sqlitePlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/sqlitePlaceholders.js
@@ -1,0 +1,135 @@
+/**
+ * mother/modules/databaseManager/placeholders/sqlitePlaceholders.js
+ *
+ * Handles built-in placeholder operations for the SQLite engine.
+ * Only a subset of operations are fully implemented. Others will
+ * log a debug message and return a generic result so modules do
+ * not crash when SQLite is selected.
+ */
+const notificationEmitter = require('../../../emitters/notificationEmitter');
+
+function sanitizeIdentifier(name) {
+  if (typeof name !== 'string' || !/^[A-Za-z0-9_]+$/.test(name)) {
+    throw new Error('Invalid identifier');
+  }
+  return name;
+}
+
+async function handleBuiltInPlaceholderSqlite(db, operation, params = []) {
+  switch (operation) {
+    /* ----------------------------- User Management --------------------------- */
+    case 'INIT_USER_MANAGEMENT': {
+      await db.exec(`
+        CREATE TABLE IF NOT EXISTS usermanagement_users (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          username TEXT UNIQUE NOT NULL,
+          email TEXT UNIQUE,
+          password TEXT NOT NULL,
+          first_name TEXT,
+          last_name TEXT,
+          display_name TEXT,
+          phone TEXT,
+          company TEXT,
+          website TEXT,
+          avatar_url TEXT,
+          bio TEXT,
+          token_version INTEGER DEFAULT 0,
+          created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE IF NOT EXISTS usermanagement_roles (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          role_name TEXT UNIQUE NOT NULL,
+          is_system_role INTEGER DEFAULT 0,
+          description TEXT,
+          permissions TEXT,
+          created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE IF NOT EXISTS usermanagement_user_roles (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id INTEGER,
+          role_id INTEGER,
+          created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+      `);
+      return { done: true };
+    }
+
+    case 'ADD_USER_FIELD': {
+      const fieldName = sanitizeIdentifier(params.fieldName || 'extra_field');
+      const allowed = ['TEXT', 'INTEGER', 'REAL', 'BLOB'];
+      const fieldType = allowed.includes((params.fieldType || '').toUpperCase())
+        ? params.fieldType.toUpperCase()
+        : 'TEXT';
+      await db.exec(`ALTER TABLE usermanagement_users ADD COLUMN ${fieldName} ${fieldType};`);
+      return { done: true };
+    }
+
+    /* ------------------------------ Settings -------------------------------- */
+    case 'INIT_SETTINGS_TABLES': {
+      await db.exec(`
+        CREATE TABLE IF NOT EXISTS settingsManager_cms_settings (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          key TEXT UNIQUE NOT NULL,
+          value TEXT,
+          created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+      `);
+      return { done: true };
+    }
+
+    case 'GET_SETTING': {
+      const settingKey = params[0];
+      return new Promise((resolve, reject) => {
+        db.get(
+          `SELECT value FROM settingsManager_cms_settings WHERE key = ? LIMIT 1;`,
+          [settingKey],
+          (err, row) => {
+            if (err) return reject(err);
+            resolve(row ? [row] : []);
+          }
+        );
+      });
+    }
+
+    case 'UPSERT_SETTING': {
+      const settingKey = params[0];
+      const settingValue = params[1];
+      await db.run(
+        `INSERT INTO settingsManager_cms_settings (key, value, created_at, updated_at)
+         VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP;`,
+        [settingKey, settingValue]
+      );
+      return { done: true };
+    }
+
+    case 'GET_ALL_SETTINGS': {
+      return new Promise((resolve, reject) => {
+        db.all(
+          `SELECT key, value FROM settingsManager_cms_settings ORDER BY id ASC;`,
+          [],
+          (err, rows) => {
+            if (err) return reject(err);
+            resolve(rows);
+          }
+        );
+      });
+    }
+
+    /* ------------------------------ Default --------------------------------- */
+    default:
+      notificationEmitter.notify({
+        moduleName: 'databaseManager',
+        notificationType: 'debug',
+        priority: 'debug',
+        message: `[PLACEHOLDER][SQLite] Unhandled built-in placeholder "${operation}". Doing nothing...`
+      });
+      return { message: `No SQLite handler for ${operation}` };
+  }
+}
+
+module.exports = { handleBuiltInPlaceholderSqlite };

--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -24,6 +24,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.10.0",
         "pg": "^8.13.1",
+        "sqlite3": "^5.1.6",
         "uuid": "^11.0.3"
     },
     "devDependencies": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Documentation on why custom post types aren't necessary (see `docs/custom_post_types.md`).
 - Added UI screenshots to the README and usage guide for easier onboarding.
 - Expanded dashboard screenshot series to illustrate widget arrangement.
+- Experimental SQLite support added alongside Postgres and MongoDB.
 
 
 ## [0.3.1] – 2025-06-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Added UI screenshots to the README and usage guide for easier onboarding.
 - Expanded dashboard screenshot series to illustrate widget arrangement.
 - Experimental SQLite support added alongside Postgres and MongoDB.
+- Added SQLite placeholder handler to support built-in operations.
 
 
 ## [0.3.1] – 2025-06-03

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You get the power of plugins — without the plugin drama.
 - 🔐 JWT-secured event system (no rogue code allowed)
 - ⚙️ Built-in sandbox for third-party modules (crash protection included)
 - 🛡️ Hardened security layer with granular permissions
-- 📦 PostgreSQL *or* MongoDB – you choose
+- 📦 PostgreSQL, MongoDB or SQLite – you choose
 - 💠 Drag-and-drop pages thanks to GridStack
 - 🧠 AI & Microservices support (because why not?)
 - ☢️ Meltdown event bus keeps rogue modules isolated

--- a/docs/choosing_database_engine.md
+++ b/docs/choosing_database_engine.md
@@ -1,6 +1,6 @@
 # Choosing a Database Engine
 
-BlogposterCMS can use either **PostgreSQL** or **MongoDB** for storing content. The selected engine is controlled through the `CONTENT_DB_TYPE` environment variable.
+BlogposterCMS can use **PostgreSQL**, **MongoDB** or **SQLite** for storing content. The selected engine is controlled through the `CONTENT_DB_TYPE` environment variable.
 
 ## PostgreSQL
 - Fully tested with BlogposterCMS.
@@ -11,9 +11,13 @@ BlogposterCMS can use either **PostgreSQL** or **MongoDB** for storing content. 
 - Support is experimental and not yet thoroughly tested.
 - Only choose MongoDB if you are comfortable debugging potential issues.
 
+## SQLite
+- Suitable for lightweight setups or testing.
+- Uses a single file stored at `SQLITE_STORAGE/SQLITE_MAIN_FILE`.
+
 ## How to Select
-1. Open `.env` and set `CONTENT_DB_TYPE` to either `postgres` or `mongodb`.
-2. Provide the matching connection credentials (`PG_*` variables for Postgres, `MONGODB_URI` for MongoDB).
+1. Open `.env` and set `CONTENT_DB_TYPE` to `postgres`, `mongodb` or `sqlite`.
+2. Provide the matching connection credentials (`PG_*` variables for Postgres, `MONGODB_URI` for MongoDB, `SQLITE_*` for SQLite).
 3. Restart the CMS so the database manager picks up the new settings.
 
 Keep your database credentials private and restrict access to the minimal privileges required.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,8 +10,8 @@ Key variables to review:
 |----------|---------|
 | `PORT` | HTTP port used by the server. |
 | `JWT_SECRET` | Base secret for token signing. **Change this** before going live. |
-| `CONTENT_DB_TYPE` | Choose `postgres` or `mongodb`. |
-| `PG_*` / `MONGODB_URI` | Database connection settings. |
+| `CONTENT_DB_TYPE` | Choose `postgres`, `mongodb` or `sqlite`. |
+| `PG_*` / `MONGODB_URI` / `SQLITE_*` | Database connection settings. |
 | `AUTH_MODULE_INTERNAL_SECRET` | Shared secret used by the auth module when issuing tokens. |
 | `TOKEN_SALT_HIGH` etc. | Additional salts used to derive secrets per trust level. |
 | `ENABLE_API` | Enables a lightweight REST API on `API_PORT` when set to `true`. |

--- a/docs/modules/databaseManager.md
+++ b/docs/modules/databaseManager.md
@@ -23,7 +23,7 @@ The Database Manager acts as the gateway between modules and the persistence lay
 The manager also emits `deactivateModule` if a module triggers a fatal error. Every call is validated against the provided JWT before any database operation is executed.
 
 ## Database Engines
-The manager works with either **PostgreSQL** or **MongoDB** as selected by the `CONTENT_DB_TYPE` variable. PostgreSQL is fully tested and recommended for production use. MongoDB support is experimental. See [Choosing a Database Engine](../choosing_database_engine.md) for configuration details.
+The manager works with **PostgreSQL**, **MongoDB** or **SQLite** as selected by the `CONTENT_DB_TYPE` variable. PostgreSQL is fully tested and recommended for production use. MongoDB support is experimental. SQLite is intended for lightweight deployments. See [Choosing a Database Engine](../choosing_database_engine.md) for configuration details.
 
 ## Placeholder Switch Cases
 Operations may reference built‑in placeholders such as `createUserTable` or custom ones registered by modules. The manager checks these placeholders before running raw SQL:


### PR DESCRIPTION
## Summary
- provide SQLite engine and register it
- allow `sqlite` value for `CONTENT_DB_TYPE`
- document new settings and update database guides
- mention SQLite option in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fe94cb3308328a509b01aaf46cff7