### PR TITLE
Add CI placeholder parity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,12 @@ jobs:
           cache-dependency-path: BlogposterCMS/package-lock.json
       - name: Install dependencies
         run: npm ci
-      - name: Build
-        run: npm run build
       - name: Run vulnerability audit
         run: npm audit --audit-level=high
+      - name: Build
+        run: npm run build
+      - name: Verify placeholder parity
+        run: npm run placeholder-parity
       - name: Run test suite
         run: npm test
 

--- a/BlogposterCMS/package-lock.json
+++ b/BlogposterCMS/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "blogposter_cms",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "blogposter_cms",
-            "version": "0.3.1",
+            "version": "0.4.0",
             "dependencies": {
                 "@rc-component/color-picker": "^2.0.1",
                 "axios": "^1.7.7",

--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blogposter_cms",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "main": "app.js",
     "scripts": {
         "start": "node app.js",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+## [0.4.0] – 2025-06-04
+- CI now verifies placeholder parity for Postgres, MongoDB and SQLite on every
+  push.
 - Replaced SQLite placeholder handler with full Postgres parity and added
   automated parity test.
 - Added Mongo placeholder parity test and CLI command to validate database placeholders.
-
 - Documentation on why custom post types aren't necessary (see `docs/custom_post_types.md`).
 - Added UI screenshots to the README and usage guide for easier onboarding.
 - Expanded dashboard screenshot series to illustrate widget arrangement.


### PR DESCRIPTION
## Summary
- run vulnerability audit before parity checks as part of CI
- bump version to 0.4.0 and document release

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_684016bb75a4832893067ec8656fbe0b