### PR TITLE
Allow DB manager to skip Postgres

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/dbSetup.js
+++ b/BlogposterCMS/mother/modules/databaseManager/dbSetup.js
@@ -3,6 +3,7 @@
  */
 const { Pool } = require('pg');
 const { pgAdminUser, pgAdminPass, pgHost, pgPort, pgMainDb } = require('./config/databaseConfig');
+const { getDbType } = require('./helpers/dbTypeHelpers');
 
 // NEW: typed notifications
 const notificationEmitter = require('../../emitters/notificationEmitter');
@@ -33,7 +34,16 @@ async function initializeDatabaseManagerDatabase(motherEmitter, coreToken) {
     );
   });
 
-  await initializeDatabaseManagerSchemaInMainDb();
+  if (getDbType() === 'postgres') {
+    await initializeDatabaseManagerSchemaInMainDb();
+  } else {
+    notificationEmitter.notify({
+      moduleName: 'databaseManager',
+      notificationType: 'debug',
+      priority: 'debug',
+      message: '[DB MANAGER] Skipping Postgres-specific schema setup.'
+    });
+  }
 }
 
 async function initializeDatabaseManagerSchemaInMainDb() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Fixed database engine selection. The `.env` variable `CONTENT_DB_TYPE`
   now overrides the legacy `DB_TYPE` to match the documentation.
+- The internal database manager no longer requires PostgreSQL when
+  `CONTENT_DB_TYPE` is set to `mongodb` or `sqlite`.
 
 ## [0.4.1] – 2025-06-04
 ### Fixed

--- a/docs/choosing_database_engine.md
+++ b/docs/choosing_database_engine.md
@@ -20,4 +20,8 @@ BlogposterCMS can use **PostgreSQL**, **MongoDB** or **SQLite** for storing cont
 2. Provide the matching connection credentials (`PG_*` variables for Postgres, `MONGODB_URI` for MongoDB, `SQLITE_*` for SQLite).
 3. Restart the CMS so the database manager picks up the new settings.
 
+When selecting `postgres` the manager will store its metadata in the main
+database under the `databasemanager` schema. This step is skipped when using
+MongoDB or SQLite.
+
 Keep your database credentials private and restrict access to the minimal privileges required.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,10 @@ Key variables to review:
 | `ENABLE_API` | Enables a lightweight REST API on `API_PORT` when set to `true`. |
 | `ALLOW_REGISTRATION` | If `true`, users may self-register via the public event. |
 
+> **Note:** When `CONTENT_DB_TYPE` is `postgres` the database manager will
+> create a `databasemanager` schema inside the main Postgres database. This step
+> is skipped for MongoDB or SQLite installs.
+
 For advanced deployments you can override defaults by creating
 `config/runtime.local.js` or `config/security.local.js`. These files are
 ignored by Git so your private values remain secret.


### PR DESCRIPTION
## Summary
- allow databaseManager to skip Postgres-specific setup when using sqlite or mongodb
- clarify DB engine docs accordingly
- changelog update

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68404e0d349083289ab94c809c8698a0