### PR TITLE
Fix SQLite init race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
   now overrides the legacy `DB_TYPE` to match the documentation.
 - The internal database manager no longer requires PostgreSQL when
   `CONTENT_DB_TYPE` is set to `mongodb` or `sqlite`.
+- Fixed SQLite initialization race for settingsManager tables and added
+  compatibility with older SQLite versions.
 
 ## [0.4.1] – 2025-06-04
 ### Fixed


### PR DESCRIPTION
## Summary
- make SQLite DB operations use Promises and wait properly
- handle missing `ADD COLUMN IF NOT EXISTS` support on old SQLite
- document fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405a88c6548328b708f56f04d880b2