### PR TITLE
Fix SQLite lastID retrieval

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/engines/sqliteEngine.js
+++ b/BlogposterCMS/mother/modules/databaseManager/engines/sqliteEngine.js
@@ -20,7 +20,12 @@ const { promisify } = require('util');
 
 function promisifyDbMethods(db) {
   return {
-    run: (...args) => new Promise((resolve, reject) => db.run(...args, err => err ? reject(err) : resolve())),
+    run: (...args) => new Promise((resolve, reject) => {
+      db.run(...args, function (err) {
+        if (err) return reject(err);
+        resolve({ lastID: this.lastID, changes: this.changes });
+      });
+    }),
     exec: (sql) => new Promise((resolve, reject) => db.exec(sql, err => err ? reject(err) : resolve())),
     get: (...args) => new Promise((resolve, reject) => db.get(...args, (err, row) => err ? reject(err) : resolve(row))),
     all: (...args) => new Promise((resolve, reject) => db.all(...args, (err, rows) => err ? reject(err) : resolve(rows))),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Verified all SQLite placeholders across modules to ensure inserted IDs use the new return value.
+- SQLite engine now returns `{ lastID, changes }` for write operations,
+  preventing `Cannot destructure property 'lastID'` errors during page creation.
 - Resolved SQLite errors on startup by avoiding `ALTER TABLE ... IF NOT EXISTS`
   and by removing Postgres schema notation when using SQLite.
 - Fixed database engine selection. The `.env` variable `CONTENT_DB_TYPE`


### PR DESCRIPTION
## Summary
- allow sqlite engine `run()` to return lastID and changes
- verify other placeholders handle SQLite IDs
- document fix in changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684062e1bc348328a5c5910bb7b0594f