### PR TITLE
Fix media folder init and image widget data

### DIFF
--- a/BlogposterCMS/mother/modules/mediaManager/index.js
+++ b/BlogposterCMS/mother/modules/mediaManager/index.js
@@ -69,11 +69,12 @@ module.exports = {
  *  Creates the library folder if it doesn't exist yet.
  */
 function ensureLibraryFolder() {
-  if (!fs.existsSync(libraryRoot)) {
-    fs.mkdirSync(libraryRoot, { recursive: true });
-    console.log(`[MEDIA MANAGER] Library folder created => ${libraryRoot}`);
-  } else {
-    console.log('[MEDIA MANAGER] Library folder already exists =>', libraryRoot);
+  const publicDir = path.join(libraryRoot, 'public');
+  try {
+    fs.mkdirSync(publicDir, { recursive: true });
+    console.log('[MEDIA MANAGER] Library folders ensured =>', libraryRoot);
+  } catch (err) {
+    console.error('[MEDIA MANAGER] Failed to create library folders:', err.message);
   }
 }
 

--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -104,7 +104,11 @@ function renderWidget(wrapper, def, code = null, lane = 'public') {
     return;
   }
   const host = wrapper.closest('.grid-stack-item') || wrapper;
-  const ctx = { id: host.dataset.instanceId, metadata: def.metadata };
+  const ctx = {
+    id: host.dataset.instanceId,
+    widgetId: def.id,
+    metadata: def.metadata
+  };
   if (lane === 'admin' && window.ADMIN_TOKEN) {
     ctx.jwt = window.ADMIN_TOKEN;
   }

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -161,7 +161,11 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       }
       return;
     }
-    const ctx = { id: instanceId, metadata: widgetDef.metadata };
+    const ctx = {
+      id: instanceId,
+      widgetId: widgetDef.id,
+      metadata: widgetDef.metadata
+    };
     if (window.ADMIN_TOKEN) {
       ctx.jwt = window.ADMIN_TOKEN;
     }

--- a/BlogposterCMS/public/assets/plainspace/public/headingWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/headingWidget.js
@@ -46,7 +46,7 @@ export function render(el, ctx = {}) {
             jwt: ctx.jwt,
             moduleName: 'widgetManager',
             moduleType: 'core',
-            widgetId: ctx.id,
+            widgetId: ctx.widgetId,
             widgetType: 'public',
             newCategory: newLevel
           });
@@ -63,7 +63,7 @@ export function render(el, ctx = {}) {
           jwt: ctx.jwt,
           moduleName: 'widgetManager',
           moduleType: 'core',
-          widgetId: ctx.id,
+          widgetId: ctx.widgetId,
           widgetType: 'public',
           newLabel: newText
         });

--- a/BlogposterCMS/public/assets/plainspace/public/imageWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/imageWidget.js
@@ -19,7 +19,7 @@ export function render(el, ctx = {}) {
             jwt: ctx.jwt,
             moduleName: 'widgetManager',
             moduleType: 'core',
-            widgetId: ctx.id,
+            widgetId: ctx.widgetId,
             widgetType: 'public',
             newCategory: shareURL
           });

--- a/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
@@ -18,7 +18,7 @@ export async function render(el, ctx = {}) {
             jwt: ctx.jwt,
             moduleName: 'widgetManager',
             moduleType: 'core',
-            widgetId: ctx.id,
+            widgetId: ctx.widgetId,
             widgetType: 'public',
             newLabel: html
           });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Ensured `library/public` directory is created during startup so media uploads don't fail.
+- Fixed image widget state persistence by passing `widgetId` to widgets.
 - Fixed missing CSRF token on admin subpages causing 403 errors when uploading media.
 - Added token validation on all admin routes and the meltdown API to prevent
   unauthorized access after a database reset.


### PR DESCRIPTION
## Summary
- ensure library/public folder exists on startup
- pass widgetId to renderers and update widget modules accordingly
- persist edits for text, heading, and image widgets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841192c591c8328a36909a270320e94