### PR TITLE
Fix share link domain fallback

### DIFF
--- a/BlogposterCMS/env.sample
+++ b/BlogposterCMS/env.sample
@@ -1,6 +1,7 @@
 # Basic Configuration
 PORT=3000
 JWT_SECRET=YOUR_SECURE_JWT_SECRET_HERE
+APP_BASE_URL=https://example.com
 
 # Database Configuration
 PG_MAIN_DB=your_database_name

--- a/BlogposterCMS/mother/modules/shareManager/index.js
+++ b/BlogposterCMS/mother/modules/shareManager/index.js
@@ -131,7 +131,7 @@ function setupShareEventListeners(motherEmitter) {
           if (err) return callback(err);
 
           // Suppose bridging returns something, or we just build a final URL
-          const baseDomain = process.env.APP_BASE_URL || 'https://myapp.com';
+          const baseDomain = process.env.APP_BASE_URL || 'https://example.com';
           const fileName = extractFileName(filePath);
           const shareURL = `${baseDomain}/s/${shortToken}/${fileName}`;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fixed default share link domain; now uses `APP_BASE_URL` or `https://example.com`.
 - Fixed missing CSRF token on admin subpages causing 403 errors when uploading media.
 - Added token validation on all admin routes and the meltdown API to prevent
   unauthorized access after a database reset.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ Key variables to review:
 |----------|---------|
 | `PORT` | HTTP port used by the server. |
 | `JWT_SECRET` | Base secret for token signing. **Change this** before going live. |
+| `APP_BASE_URL` | Public URL used for share links and sitemaps. |
 | `CONTENT_DB_TYPE` | Choose `postgres`, `mongodb` or `sqlite`. |
 | `PG_*` / `MONGODB_URI` / `SQLITE_*` | Database connection settings. |
 | `AUTH_MODULE_INTERNAL_SECRET` | Shared secret used by the auth module when issuing tokens. |

--- a/docs/modules/shareManager.md
+++ b/docs/modules/shareManager.md
@@ -16,3 +16,6 @@ Creates secure share links for files managed by the Media Manager.
 - `getShareDetails`
 
 Token permissions are checked to prevent unauthorised downloads.
+
+The URL for generated share links is determined by the `APP_BASE_URL`
+environment variable. If unset, it defaults to `https://example.com`.


### PR DESCRIPTION
## Summary
- set `APP_BASE_URL` sample value and use it for share links
- document `APP_BASE_URL` in configuration docs and share manager docs
- describe the new setting in `env.sample`
- log the change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68411be4cf6c8328a5e8c280ec931367