### PR TITLE
Fix release changelog path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: javascript
-          working-directory: BlogposterCMS
+          source-root: BlogposterCMS
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
       - name: Zip Build Artifacts
@@ -65,7 +65,7 @@ jobs:
       - name: Read CHANGELOG.md
         id: changelog
         run: |
-          RELEASE_NOTES=$(awk '/^## /{flag=1;next}/^$/{if(flag) exit}flag' BlogposterCMS/CHANGELOG.md)
+          RELEASE_NOTES=$(awk '/^## /{flag=1;next}/^$/{if(flag) exit}flag' CHANGELOG.md)
           echo "notes<<EOF" >> $GITHUB_ENV
           echo "$RELEASE_NOTES" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Adjusted release workflow to read the changelog from the repository root.
 - Fixed missing CSRF token on admin subpages causing 403 errors when uploading media.
 - Added token validation on all admin routes and the meltdown API to prevent
   unauthorized access after a database reset.


### PR DESCRIPTION
## Summary
- fix CodeQL setup and changelog path in release workflow
- note new changelog entry for workflow fix

## Testing
- `npm run placeholder-parity`
- `npm run build`
- `npm test`
- `npm audit --audit-level=high` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841386ad83c83288b77a6c826e53b22