### PR TITLE
Fix Jest open handle due to setAsStart test

### DIFF
--- a/BlogposterCMS/tests/setAsStart.test.js
+++ b/BlogposterCMS/tests/setAsStart.test.js
@@ -49,8 +49,12 @@ async function testSetAsStartLanguage() {
   };
   let lastUpdate = null;
 
-  emitter.on('getPageById', (payload, cb) => {
-    cb(null, pages[payload.pageId] || null);
+  emitter.on('dbSelect', (payload, cb) => {
+    if (payload.data?.rawSQL === 'GET_PAGE_BY_ID') {
+      const pageId = payload.data[0];
+      return cb(null, pages[pageId] || null);
+    }
+    cb(null, null);
   });
 
   emitter.on('dbUpdate', (payload, cb) => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Resolved open handle warning in Jest by stubbing `dbSelect` in the
+  `setAsStart` test.
 - Updated placeholder parity check to invoke Jest so the script works again.
 - Switched test runner to Jest and converted all integration tests.
 - Adjusted release workflow to read the changelog from the repository root.


### PR DESCRIPTION
## Summary
- patch setAsStart test to stub `dbSelect` instead of `getPageById`
- document fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68414ddea79883288e1e22df0efd570e