### PR TITLE
Fix MongoDB CRUD support

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/engines/mongoEngine.js
+++ b/BlogposterCMS/mother/modules/databaseManager/engines/mongoEngine.js
@@ -88,6 +88,12 @@ async function performMongoOperation(moduleName, operation, params = []) {
       } else if (operation === 'find') {
         const { collectionName, query } = params;
         return await db.collection(collectionName).find(query || {}).toArray();
+      } else if (operation === 'updateOne') {
+        const { collectionName, query, update, options } = params;
+        return await db.collection(collectionName).updateOne(query, update, options || {});
+      } else if (operation === 'deleteOne') {
+        const { collectionName, query } = params;
+        return await db.collection(collectionName).deleteOne(query);
       }
       throw new Error(`[MongoEngine] Unsupported operation="${operation}".`);
     }

--- a/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/highLevelCrudEvents.js
+++ b/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/highLevelCrudEvents.js
@@ -287,6 +287,23 @@ function localDbInsert(motherEmitter, payload, callback) {
   }
 
   // Normal insert approach
+  if (getDbType() === 'mongodb') {
+    motherEmitter.emit(
+      'performDbOperation',
+      {
+        jwt,
+        moduleName,
+        operation: 'insertOne',
+        params: { collectionName: table, doc: data }
+      },
+      (err, result) => {
+        if (err) return callback(err);
+        callback(null, result);
+      }
+    );
+    return;
+  }
+
   const columns = Object.keys(data);
   if (!columns.length) {
     return callback(new Error('[localDbInsert] No columns in data.'));
@@ -340,6 +357,23 @@ function localDbSelect(motherEmitter, payload, callback) {
   }
 
   // Normal SELECT approach
+  if (getDbType() === 'mongodb') {
+    motherEmitter.emit(
+      'performDbOperation',
+      {
+        jwt,
+        moduleName,
+        operation: 'find',
+        params: { collectionName: table, query: where || {} }
+      },
+      (err, result) => {
+        if (err) return callback(err);
+        callback(null, result || []);
+      }
+    );
+    return;
+  }
+
   let whereClause = '';
   let values = [];
   if (where && Object.keys(where).length > 0) {
@@ -391,6 +425,23 @@ function localDbUpdate(motherEmitter, payload, callback) {
   }
 
   // Normal UPDATE approach
+  if (getDbType() === 'mongodb') {
+    motherEmitter.emit(
+      'performDbOperation',
+      {
+        jwt,
+        moduleName,
+        operation: 'updateOne',
+        params: { collectionName: table, query: where, update: { $set: data } }
+      },
+      (err, result) => {
+        if (err) return callback(err);
+        callback(null, result);
+      }
+    );
+    return;
+  }
+
   const setKeys = Object.keys(data || {});
   if (!setKeys.length) {
     return callback(new Error('[localDbUpdate] No update data provided.'));
@@ -468,6 +519,23 @@ function localDbDelete(motherEmitter, payload, callback) {
   if (!whereKeys.length) {
     return callback(new Error('[localDbDelete] Empty WHERE => refusing to delete everything.'));
   }
+  if (getDbType() === 'mongodb') {
+    motherEmitter.emit(
+      'performDbOperation',
+      {
+        jwt,
+        moduleName,
+        operation: 'deleteOne',
+        params: { collectionName: table, query: where }
+      },
+      (err, result) => {
+        if (err) return callback(err);
+        callback(null, result);
+      }
+    );
+    return;
+  }
+
   const whereClauses = whereKeys.map((col, i) => `"${col}" = ${ph(i+1)}`);
   const whereValues = Object.values(where);
 

--- a/BlogposterCMS/package-lock.json
+++ b/BlogposterCMS/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "blogposter_cms",
-    "version": "0.4.1",
+    "version": "0.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "blogposter_cms",
-            "version": "0.4.1",
+            "version": "0.4.3",
             "dependencies": {
                 "@rc-component/color-picker": "^2.0.1",
                 "axios": "^1.7.7",

--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blogposter_cms",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "main": "app.js",
     "scripts": {
         "start": "node app.js",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fixed MongoDB integration. Local CRUD events now translate to Mongo operations
+  instead of raw SQL, enabling proper widget management and other features when
+  `CONTENT_DB_TYPE` is set to `mongodb`.
 - Resolved open handle warning in Jest by stubbing `dbSelect` in the
   `setAsStart` test.
 - Updated placeholder parity check to invoke Jest so the script works again.


### PR DESCRIPTION
## Summary
- support basic MongoDB operations in CRUD helpers
- wire Mongo CRUD operations into localDb helpers
- bump version to 0.4.3
- document Mongo fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684163d77b3083288696917a46bda390