### PR TITLE
Fix widgetManager startup errors

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/performDbOperationEvent.js
+++ b/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/performDbOperationEvent.js
@@ -46,8 +46,11 @@ function registerPerformDbOperationEvent(motherEmitter) {
       }
       const { moduleName, operation, params } = payload;
 
-      // Basic validation of required parameters
-      if (!moduleName || !operation || !Array.isArray(params)) {
+      // Basic validation of required parameters. Historically this
+      // listener only allowed an array for `params`, but newer MongoDB
+      // helpers pass an object.  Support both to avoid needless errors.
+      const paramsValid = Array.isArray(params) || (params && typeof params === 'object');
+      if (!moduleName || !operation || !paramsValid) {
         // This error will be caught by the catch block below
         throw new Error(`Invalid parameters received from module "${moduleName}". Operation or params missing/invalid.`);
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fixed false "Invalid parameters" errors when MongoDB operations passed an
+  object instead of an array to `performDbOperation`. The listener now accepts
+  both formats and no longer deactivates modules like `widgetManager` during
+  startup.
 - Fixed MongoDB database initialization failing when a module user already exists.
   Settings manager now loads correctly and registers event listeners.
 - Fixed MongoDB integration. Local CRUD events now translate to Mongo operations


### PR DESCRIPTION
## Summary
- allow `performDbOperation` to accept object params for MongoDB
- update changelog

## Testing
- `npm -C BlogposterCMS test`

------
https://chatgpt.com/codex/tasks/task_e_68416f6eb0188328a689867e2ae1fae5