### PR TITLE
Fix Mongo role assignment and parity tests

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/highLevelCrudEvents.js
+++ b/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/highLevelCrudEvents.js
@@ -368,7 +368,14 @@ function localDbSelect(motherEmitter, payload, callback) {
       },
       (err, result) => {
         if (err) return callback(err);
-        callback(null, result || []);
+        const docs = (result || []).map(doc => {
+          if (doc && doc._id && !doc.id) {
+            const { _id, ...rest } = doc;
+            return { id: _id, ...rest };
+          }
+          return doc;
+        });
+        callback(null, docs);
       }
     );
     return;

--- a/BlogposterCMS/package-lock.json
+++ b/BlogposterCMS/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "blogposter_cms",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "blogposter_cms",
-            "version": "0.4.3",
+            "version": "0.4.4",
             "dependencies": {
                 "@rc-component/color-picker": "^2.0.1",
                 "axios": "^1.7.7",

--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blogposter_cms",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "main": "app.js",
     "scripts": {
         "start": "node app.js",

--- a/BlogposterCMS/tests/collectionParity.test.js
+++ b/BlogposterCMS/tests/collectionParity.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+function pgTables() {
+  const file = path.join(__dirname, '../mother/modules/databaseManager/placeholders/postgresPlaceholders.js');
+  const code = fs.readFileSync(file, 'utf8');
+  const tableRegex = /CREATE TABLE IF NOT EXISTS\s+([^\s(]+)/gi;
+  const tables = new Set();
+  let m;
+  while ((m = tableRegex.exec(code)) !== null) {
+    let name = m[1].replace(/["`]/g, '');
+    if (name.includes('.')) {
+      const [schema, table] = name.split('.');
+      name = schema === 'plainspace' ? `${schema}_${table}` : table;
+    }
+    tables.add(name);
+  }
+  return Array.from(tables).sort();
+}
+
+function mongoCollections() {
+  const file = path.join(__dirname, '../mother/modules/databaseManager/placeholders/mongoPlaceholders.js');
+  const code = fs.readFileSync(file, 'utf8');
+  const direct = /createCollection\(['"]([^'"\)]+)['"]\)/gi;
+  const variable = /const\s+collectionName\s*=\s*['"]([^'"]+)['"]/gi;
+  const cols = new Set();
+  let m;
+  while ((m = direct.exec(code)) !== null) cols.add(m[1]);
+  while ((m = variable.exec(code)) !== null) cols.add(m[1]);
+  cols.delete('widgetmanager_widgets'); // collection only used in Mongo
+  return Array.from(cols).sort();
+}
+
+test('Mongo collections match Postgres tables across modules', () => {
+  expect(mongoCollections()).toEqual(pgTables());
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file.
 - Fixed default share link domain; now uses `APP_BASE_URL` or `https://example.com`.
 - Ensured `library/public` directory is created during startup so media uploads don't fail.
 - Fixed image widget state persistence by passing `widgetId` to widgets.
+- Fixed role assignment on MongoDB. `dbSelect` now normalizes `_id` to `id`,
+  ensuring roles attach correctly during user creation.
+- Added test verifying Mongo user collections match PostgreSQL tables.
+- Extended parity test to cover all Mongo collections across modules.
 
 ## [0.4.1] – 2025-06-05
 - Fixed missing CSRF token on admin subpages causing 403 errors when uploading media.


### PR DESCRIPTION
## Summary
- normalize Mongo `_id` fields to `id` in `localDbSelect`
- add a parity test ensuring Mongo user collections match PostgreSQL tables
- extend parity test to verify every Mongo collection corresponds to a Postgres table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684180153bd08328b75a37508811f90d