### PR TITLE
Fix MongoDB deprecation warning

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/engines/mongoEngine.js
+++ b/BlogposterCMS/mother/modules/databaseManager/engines/mongoEngine.js
@@ -135,7 +135,7 @@ async function connectToModuleDb(moduleName) {
     ? mongoUri
     : `mongodb://${dbUser}:${dbPass}@${mongoHost}:${mongoPort}/${dbName}?authSource=${dbName}`;
 
-  const client = new MongoClient(connectUri, { useUnifiedTopology: true });
+  const client = new MongoClient(connectUri);
   await client.connect();
   return client.db(dbName);
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Removed deprecated `useUnifiedTopology` option from MongoDB connections to avoid warnings.
 - Fixed false "Invalid parameters" errors when MongoDB operations passed an
   object instead of an array to `performDbOperation`. The listener now accepts
   both formats and no longer deactivates modules like `widgetManager` during


### PR DESCRIPTION
## Summary
- remove deprecated `useUnifiedTopology` option from mongo engine
- document the change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418622905c83288762f406a3a1cb0a