### PR TITLE
Fix login role detection on MongoDB

### DIFF
--- a/BlogposterCMS/mother/modules/userManagement/roleCrudEvents.js
+++ b/BlogposterCMS/mother/modules/userManagement/roleCrudEvents.js
@@ -291,7 +291,8 @@ function setupRoleCrudEvents(motherEmitter) {
         return callback(null, []);
       }
 
-      const roleIds = userRoles.map(ur => ur.role_id);
+      // Normalize to string to avoid ObjectId strict equality issues
+      const roleIds = userRoles.map(ur => String(ur.role_id));
       console.log('[USER MGMT] getRolesForUser => user_roles found. Role IDs:', roleIds);
 
       // Now select from 'roles' to return role objects
@@ -304,7 +305,7 @@ function setupRoleCrudEvents(motherEmitter) {
           console.error('[USER MGMT] getRolesForUser => Error selecting roles:', err2.message);
           return callback(err2);
         }
-        const matched = (allRoles || []).filter(r => roleIds.includes(r.id));
+        const matched = (allRoles || []).filter(r => roleIds.includes(String(r.id)));
         console.log('[USER MGMT] getRolesForUser => Matched roles count:', matched?.length || 0);
         callback(null, matched);
       });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fixed role lookup when logging in on MongoDB setups. Role IDs are now compared as strings to avoid ObjectId mismatches.
 - Fixed user login failing on MongoDB setups. `getUserDetailsById` now queries `_id` instead of `id`, so finalize login works properly.
 - Removed deprecated `useUnifiedTopology` option from MongoDB connections to avoid warnings.
 - Fixed false "Invalid parameters" errors when MongoDB operations passed an


### PR DESCRIPTION
## Summary
- fix role lookup for MongoDB by normalizing ids to strings
- document fix in changelog

## Testing
- `npm test -s`

------
https://chatgpt.com/codex/tasks/task_e_68418cdcd14883288fb95056971cf562