### PR TITLE
Improve log security for userManagement

### DIFF
--- a/BlogposterCMS/mother/modules/userManagement/loginEvents.js
+++ b/BlogposterCMS/mother/modules/userManagement/loginEvents.js
@@ -15,7 +15,9 @@ function setupLoginEvents(motherEmitter) {
   motherEmitter.on('userLogin', async (payload, originalCb) => {
     const callback = onceCallback(originalCb);
 
-    console.log('[USER MGMT] "userLogin" event triggered. Payload:', payload);
+    const sanitized = { ...payload };
+    if (sanitized && sanitized.password) sanitized.password = '***';
+    console.log('[USER MGMT] "userLogin" event triggered. Payload:', sanitized);
     const { jwt, moduleName, moduleType, username, password } = payload || {};
 
     if (!jwt || moduleName !== 'userManagement' || moduleType !== 'core') {

--- a/BlogposterCMS/mother/modules/userManagement/roleCrudEvents.js
+++ b/BlogposterCMS/mother/modules/userManagement/roleCrudEvents.js
@@ -18,6 +18,7 @@ const TIMEOUT_DURATION = 5000;
 // meltdown meltdown...
 const { onceCallback } = require('../../emitters/motherEmitter');
 const { hasPermission } = require('./permissionUtils');
+const { getDbType } = require('../databaseManager/helpers/dbTypeHelpers');
 
 /**
  * setupRoleCrudEvents:
@@ -240,11 +241,12 @@ function setupRoleCrudEvents(motherEmitter) {
       }
 
       // On success => increment the user's token_version
+      const idField = getDbType() === 'mongodb' ? '_id' : 'id';
       motherEmitter.emit('dbUpdate', {
         jwt,
         moduleName: 'userManagement',
         table: 'users',
-        where: { id: userId },
+        where: { [idField]: userId },
         data: {
           token_version: { '__raw_expr': 'token_version + 1' }
         }
@@ -340,11 +342,12 @@ function setupRoleCrudEvents(motherEmitter) {
       if (err) return callback(err);
 
       // Then increment token_version
+      const idField = getDbType() === 'mongodb' ? '_id' : 'id';
       motherEmitter.emit('dbUpdate', {
         jwt,
         moduleName: 'userManagement',
         table: 'users',
-        where: { id: userId },
+        where: { [idField]: userId },
         data: {
           token_version: { '__raw_expr': 'token_version + 1' }
         }
@@ -372,11 +375,12 @@ function setupRoleCrudEvents(motherEmitter) {
     }
 
     console.log('[USER MGMT] incrementUserTokenVersion => Fetching current token_version for userId:', userId);
+    const idField = getDbType() === 'mongodb' ? '_id' : 'id';
     motherEmitter.emit('dbSelect', {
       jwt,
       moduleName: 'userManagement',
       table: 'users',
-      where: { id: userId }
+      where: { [idField]: userId }
     }, (selectErr, users) => {
       if (selectErr || !users.length) {
         console.error('[USER MGMT] incrementUserTokenVersion => Error or no user found:', selectErr?.message || 'No user');
@@ -390,7 +394,7 @@ function setupRoleCrudEvents(motherEmitter) {
         jwt,
         moduleName: 'userManagement',
         table: 'users',
-        where: { id: userId },
+        where: { [idField]: userId },
         data: { token_version: currentTokenVersion + 1 }
       }, (updateErr) => {
         if (updateErr) {

--- a/BlogposterCMS/mother/modules/userManagement/userCrudEvents.js
+++ b/BlogposterCMS/mother/modules/userManagement/userCrudEvents.js
@@ -26,7 +26,9 @@ function setupUserCrudEvents(motherEmitter) {
   motherEmitter.on('createUser', async (payload, originalCb) => {
     const callback = onceCallback(originalCb);
 
-    console.log('[USER MGMT] "createUser" event triggered. Payload:', payload);
+    const sanitized = { ...payload };
+    if (sanitized && sanitized.password) sanitized.password = '***';
+    console.log('[USER MGMT] "createUser" event triggered. Payload:', sanitized);
 
     const {
       jwt,
@@ -115,7 +117,9 @@ function setupUserCrudEvents(motherEmitter) {
           return callback(new Error('No valid inserted user row'));
         }
       
-        console.log('[USER MGMT] createUser => User inserted:', newUser);
+        const userLog = { ...newUser };
+        if (userLog && userLog.password) userLog.password = '***';
+        console.log('[USER MGMT] createUser => User inserted:', userLog);
       
         if (!role) {
           clearTimeout(timeout);
@@ -347,7 +351,9 @@ function setupUserCrudEvents(motherEmitter) {
   motherEmitter.on('updateUserProfile', async (payload, originalCb) => {
     const callback = onceCallback(originalCb);
 
-    console.log('[USER MGMT] "updateUserProfile" event triggered. Payload:', payload);
+    const sanitizedPayload = { ...payload };
+    if (sanitizedPayload && sanitizedPayload.newPassword) sanitizedPayload.newPassword = '***';
+    console.log('[USER MGMT] "updateUserProfile" event triggered. Payload:', sanitizedPayload);
 
     const {
       jwt,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Masked password fields in updateUserProfile and user creation logs to prevent
+  leaking credentials during debugging.
+- Fixed token_version updates on MongoDB. Role assignments now use `_id` when
+  incrementing the version so user tokens invalidate correctly.
+- Masked passwords in userManagement logs to avoid credential leaks.
 - Fixed pagesManager start page setup on MongoDB. `SET_AS_START` no longer uses
   an undefined `client` object, preventing module meltdown and login failures.
 - Fixed role lookup when logging in on MongoDB setups. Role IDs are now compared as strings to avoid ObjectId mismatches.


### PR DESCRIPTION
## Summary
- hide password values in userLogin and createUser logs
- update token_version for MongoDB using `_id`
- mask passwords in updateUserProfile and sanitized user creation logs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841964e2918832887c076338b41188c