### PR TITLE
Add admin token warnings

### DIFF
--- a/BlogposterCMS/app.js
+++ b/BlogposterCMS/app.js
@@ -295,6 +295,7 @@ app.post('/api/meltdown', apiLimiter, async (req, res) => {
       payload.decodedJWT = await validateAdminToken(jwt);
       payload.jwt = jwt;
     } catch (err) {
+      console.warn('[POST /api/meltdown] Invalid admin token =>', err.message);
       res.clearCookie('admin_jwt', {
         path: '/',
         httpOnly: true,
@@ -436,7 +437,8 @@ app.get('/admin/home', pageLimiter, csrfProtection, async (req, res) => {
           `<meta name="csrf-token" content="${req.csrfToken()}"></head>`
         );
         return res.send(html);
-      } catch {
+      } catch (err) {
+        console.warn('[GET /admin/home] Invalid admin token =>', err.message);
         res.clearCookie('admin_jwt', {
           path: '/',
           httpOnly: true,
@@ -480,7 +482,8 @@ app.get('/admin/*', pageLimiter, csrfProtection, async (req, res, next) => {
 
   try {
     await validateAdminToken(adminJwt);
-  } catch {
+  } catch (err) {
+    console.warn('[GET /admin/*] Invalid admin token =>', err.message);
     res.clearCookie('admin_jwt', {
       path: '/',
       httpOnly: true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Added warnings when admin_jwt cookies are cleared due to invalid tokens.
 - Removed `config/environment.js`; `isProduction` now comes from `config/runtime.js`.
 - Documented HTTPS requirement for login cookies in `docs/security.md`.
 - Added warning when secure login cookies are set over HTTP.


### PR DESCRIPTION
## Summary
- log a warning when stale admin_jwt cookies are cleared in `/api/meltdown`
- log a warning when stale admin_jwt cookies are cleared on `/admin/home`
- log a warning when stale admin_jwt cookies are cleared on `/admin/*`
- document new logging behaviour

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_6842b69379708328b00a30f12de32e35