### PR TITLE
Fix MongoDB ID handling in user lookup

### DIFF
--- a/BlogposterCMS/mother/modules/userManagement/userCrudEvents.js
+++ b/BlogposterCMS/mother/modules/userManagement/userCrudEvents.js
@@ -13,6 +13,7 @@
  * Also includes hashing passwords, etc.
  */
 const bcrypt = require('bcryptjs');
+const { ObjectId } = require('mongodb');
 
 const TIMEOUT_DURATION = 5000;
 
@@ -459,11 +460,19 @@ function setupUserCrudEvents(motherEmitter) {
     }, TIMEOUT_DURATION);
 
     const idField = getDbType() === 'mongodb' ? '_id' : 'id';
+    let queryId = userId;
+    if (
+      getDbType() === 'mongodb' &&
+      typeof userId === 'string' &&
+      /^[0-9a-fA-F]{24}$/.test(userId)
+    ) {
+      queryId = new ObjectId(userId);
+    }
     motherEmitter.emit('dbSelect', {
       jwt,
       moduleName: 'userManagement',
       table: 'users',
-      where: { [idField]: userId }
+      where: { [idField]: queryId }
     }, (err, rows) => {
       clearTimeout(timeout);
       if (err) return callback(err);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fixed MongoDB logins failing when userId strings were not converted to ObjectId.
 - Removed `config/environment.js`; `isProduction` now comes from `config/runtime.js`.
 - Documented HTTPS requirement for login cookies in `docs/security.md`.
 - Added warning when secure login cookies are set over HTTP.


### PR DESCRIPTION
## Summary
- convert MongoDB ID strings to `ObjectId` in `getUserDetailsById`
- import `ObjectId` helper
- note MongoDB login fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842b6a35ee8832885b68bc14f2973e8