### PR TITLE
Fix Mongo page seeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fixed MongoDB page creation to store lane, language and title so seeded pages
+  and widgets appear correctly.
 - Fixed MongoDB logins failing when userId strings were not converted to ObjectId.
 - Added warnings when admin_jwt cookies are cleared due to invalid tokens.
 - Removed `config/environment.js`; `isProduction` now comes from `config/runtime.js`.


### PR DESCRIPTION
## Summary
- fix MongoDB placeholders to store lane/title/meta when creating or updating pages
- ensure unique slug+lane index and lane field in migrations
- query by lane when fetching a page by slug
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842bbebaa0c83288825dfdddbdf86fd