### PR TITLE
Fix share link insert doc for Mongo v4

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
@@ -873,8 +873,9 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
     };
     
     const insertRes = await db.collection('shared_links').insertOne(doc);
-    // Return inserted doc
-    return insertRes.ops?.[0] || { insertedId: insertRes.insertedId };
+    // Mongo driver v4 no longer exposes insertRes.ops
+    const insertedDoc = await db.collection('shared_links').findOne({ _id: insertRes.insertedId });
+    return insertedDoc;
     }
     
     case 'REVOKE_SHARE_LINK': {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fixed Mongo `CREATE_SHARE_LINK` to return the inserted document for driver v4 compatibility.
 - Mongo `GET_PAGES_BY_LANE` now returns the same structure as Postgres with `trans_*` fields for each translation.
 - Unified `GET_PAGE_BY_SLUG` across all databases to return a single page object instead of an array.
 - Normalized Mongo `CHECK_MODULE_REGISTRY_COLUMNS` to return `{ column_name }` rows like other drivers.


### PR DESCRIPTION
## Summary
- retrieve inserted share link from MongoDB using insertedId
- document the fix in the changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843e9747e8c8328a6fa658b656a4303