### PR TITLE
Enforce UTC timestamps

### DIFF
--- a/BlogposterCMS/mother/modules/auth/authService.js
+++ b/BlogposterCMS/mother/modules/auth/authService.js
@@ -74,7 +74,7 @@ function storeRefreshTokenInDB(userId, refreshToken, expiresAt, callback) {
       data: {
         user_id: userId,
         token_value: refreshToken,
-        created_at: new Date(),
+        created_at: new Date().toISOString(),
         expires_at: expiresAt
       }
     },

--- a/BlogposterCMS/mother/modules/auth/strategies/facebook.js
+++ b/BlogposterCMS/mother/modules/auth/strategies/facebook.js
@@ -94,8 +94,8 @@ module.exports = {
                             facebook_id: userData.id,
                             email      : userData.email || null,
                             full_name  : userData.name  || null,
-                            created_at : new Date(),
-                            updated_at : new Date()
+                            created_at : new Date().toISOString(),
+                            updated_at : new Date().toISOString()
                           }
                         },
                         (insertErr, newUser) => {

--- a/BlogposterCMS/mother/modules/auth/strategies/google.js
+++ b/BlogposterCMS/mother/modules/auth/strategies/google.js
@@ -77,8 +77,8 @@ module.exports = {
                             google_id  : payload.sub,
                             email      : payload.email || null,
                             full_name  : payload.name  || null,
-                            created_at : new Date(),
-                            updated_at : new Date()
+                            created_at : new Date().toISOString(),
+                            updated_at : new Date().toISOString()
                           }
                         },
                         (insertErr, newUser) => {

--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
@@ -57,8 +57,8 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
             avatar_url: '',
             bio: '',
             token_version: 0,
-            created_at: new Date(),
-            updated_at: new Date()
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString()
           }
         });
       
@@ -69,16 +69,16 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
             is_system_role: false,
             description: '',
             permissions: {},
-            created_at: new Date(),
-            updated_at: new Date()
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString()
           }
         });
       
         // same for user_roles => just ensure created_at, updated_at
         await db.collection('user_roles').updateMany({}, {
           $set: {
-            created_at: new Date(),
-            updated_at: new Date()
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString()
           }
         });
       
@@ -150,10 +150,10 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
         {
         $set: {
             value: settingVal,
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
         },
         $setOnInsert: {
-            created_at: new Date()
+            created_at: new Date().toISOString()
         }
         },
         { upsert: true }
@@ -305,8 +305,8 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
         language   : (language || 'en').toLowerCase(),
         title      : title || '',
         meta       : meta || null,
-        created_at : new Date(),
-        updated_at : new Date()
+        created_at : new Date().toISOString(),
+        updated_at : new Date().toISOString()
       });
   
       // 2) Insert translations
@@ -319,8 +319,8 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
         meta_desc   : t.metaDesc,
         seo_title   : t.seoTitle,
         seo_keywords: t.seoKeywords,
-        created_at  : new Date(),
-        updated_at  : new Date()
+        created_at  : new Date().toISOString(),
+        updated_at  : new Date().toISOString()
       }));
       await db.collection('page_translations').insertMany(translationDocs);
   
@@ -485,7 +485,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
             language  : (language || 'en').toLowerCase(),
             title     : title || '',
             meta      : meta || null,
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
           }
         }
       );
@@ -505,7 +505,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
               meta_desc   : t.metaDesc,
               seo_title   : t.seoTitle,
               seo_keywords: t.seoKeywords,
-              updated_at  : new Date()
+              updated_at  : new Date().toISOString()
             }
           },
           { upsert: true }
@@ -561,7 +561,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
                 $set: {
                   is_start  : true,
                   language,
-                  updated_at: new Date()
+                  updated_at: new Date().toISOString()
                 }
               },
               { session }
@@ -583,7 +583,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
             $set: {
               is_start  : true,
               language,
-              updated_at: new Date()
+              updated_at: new Date().toISOString()
             }
           }
         );
@@ -790,8 +790,8 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
         server_name: serverName,
         ip_address: ipAddress,
         notes: notes || '',
-        created_at: new Date(),
-        updated_at: new Date()
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
         });
         return { done: true };
     }
@@ -826,7 +826,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
             server_name: newName,
             ip_address: newIp,
             notes: newNotes,
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
             }
         }
         );
@@ -853,8 +853,8 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
         location  : location || '',
         folder    : folder || '',
         notes     : notes || '',
-        created_at: new Date(),
-        updated_at: new Date()
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
         });
         return { done: true };
     }
@@ -891,7 +891,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
             category  : newCategory,
             notes     : newNotes,
             folder    : newFolder,
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
             }
         }
         );
@@ -919,7 +919,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
         file_path  : filePath,
         created_by : userId,
         is_public  : (isPublic !== false),
-        created_at : new Date()
+        created_at : new Date().toISOString()
     };
     
     const insertRes = await db.collection('shared_links').insertOne(doc);
@@ -1006,8 +1006,8 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
         label: label || '',
         content: content || '',
         category: category || '',
-        created_at: new Date(),
-        updated_at: new Date()
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
     });
     return { done: true };
     }
@@ -1047,7 +1047,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
             label: newLabel ?? undefined,
             content: newContent ?? undefined,
             category: newCategory ?? undefined,
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
         }
         }
     );
@@ -1078,7 +1078,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
             content: newContent ?? undefined,
             category: newCategory ?? undefined,
             order: newOrder ?? undefined,
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
           }
         }
     );
@@ -1096,7 +1096,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
             content: newContent ?? undefined,
             category: newCategory ?? undefined,
             order: newOrder ?? undefined,
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
           }
         }
     );
@@ -1142,7 +1142,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
         {
           $set: {
             layout_json: d.layoutArr || [],
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
           }
         },
         { upsert: true }
@@ -1159,7 +1159,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
             lane: d.lane,
             viewport: d.viewport,
             layout_json: d.layoutArr || [],
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
           }
         },
         { upsert: true }

--- a/BlogposterCMS/mother/modules/moduleLoader/moduleRegistryEvents.js
+++ b/BlogposterCMS/mother/modules/moduleLoader/moduleRegistryEvents.js
@@ -45,7 +45,7 @@ function initModuleRegistryAdminEvents(motherEmitter, app) {
           data: {
             is_active: true,
             last_error: null,
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
           }
         },
         async (err) => {
@@ -89,7 +89,7 @@ function initModuleRegistryAdminEvents(motherEmitter, app) {
           where: { module_name: targetModuleName },
           data: {
             is_active: false,
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
           }
         },
         (err) => {

--- a/BlogposterCMS/mother/modules/moduleLoader/moduleRegistryService.js
+++ b/BlogposterCMS/mother/modules/moduleLoader/moduleRegistryService.js
@@ -153,7 +153,7 @@ function updateModuleInfo(motherEmitter, jwt, moduleName, newInfo) {
         where: { module_name: moduleName },
         data: {
           module_info: JSON.stringify(newInfo),
-          updated_at : new Date()
+          updated_at : new Date().toISOString()
         }
       },
       (err) => {
@@ -200,8 +200,8 @@ function insertModuleRegistryEntry(motherEmitter, jwt, moduleName, isActive, las
           is_active   : isActive,
           last_error  : lastError,
           module_info : JSON.stringify(moduleInfo || {}),
-          created_at  : new Date(),
-          updated_at  : new Date()
+          created_at  : new Date().toISOString(),
+          updated_at  : new Date().toISOString()
         }
       },
       (err) => {
@@ -222,7 +222,7 @@ function updateModuleLastError(motherEmitter, jwt, moduleName, lastError) {
   return new Promise((resolve, reject) => {
     const dataObj = {
       last_error: lastError,
-      updated_at: new Date()
+      updated_at: new Date().toISOString()
     };
     if (lastError === null) {
       dataObj.is_active = true;
@@ -266,7 +266,7 @@ function deactivateModule(motherEmitter, jwt, moduleName, errMsg) {
         data       : {
           is_active  : false,
           last_error : errMsg,
-          updated_at : new Date()
+      updated_at : new Date().toISOString()
         }
       },
         (err) => {

--- a/BlogposterCMS/mother/modules/translationManager/translationCrudEvents.js
+++ b/BlogposterCMS/mother/modules/translationManager/translationCrudEvents.js
@@ -50,8 +50,8 @@ function setupTranslationCrudEvents(motherEmitter, jwt) {
             field_name: fieldName,
             language_code: languageCode,
             text_value: textValue || '',
-            created_at: new Date(),
-            updated_at: new Date()
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString()
           }
         },
         (err, insertedRow) => {
@@ -149,7 +149,7 @@ function setupTranslationCrudEvents(motherEmitter, jwt) {
           where: { id: textId },
           data: {
             text_value: newTextValue,
-            updated_at: new Date()
+            updated_at: new Date().toISOString()
           }
         },
         (err, result) => {
@@ -238,7 +238,7 @@ function setupTranslationCrudEvents(motherEmitter, jwt) {
           data: {
             language_code: languageCode,
             language_name: languageName,
-            created_at: new Date()
+            created_at: new Date().toISOString()
           }
         },
         (err, inserted) => {

--- a/BlogposterCMS/mother/modules/translationManager/translationService.js
+++ b/BlogposterCMS/mother/modules/translationManager/translationService.js
@@ -51,7 +51,7 @@ async function translateText({
           chars: text.length,
           from_lang: fromLang,
           to_lang: toLang,
-          created_at: new Date()
+          created_at: new Date().toISOString()
         }
       },
       (err, insertedUsage) => {
@@ -76,7 +76,7 @@ async function translateText({
           source_text: text,
           translated_text: translated,
           user_id: userId,
-          created_at: new Date()
+          created_at: new Date().toISOString()
         }
       },
       (err, insertedCache) => {

--- a/BlogposterCMS/mother/modules/userManagement/roleCrudEvents.js
+++ b/BlogposterCMS/mother/modules/userManagement/roleCrudEvents.js
@@ -54,8 +54,8 @@ function setupRoleCrudEvents(motherEmitter) {
         is_system_role: false,
         description: description || '',
         permissions: JSON.stringify(permJson),
-        created_at: new Date(),
-        updated_at: new Date()
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
       }
     }, (err, insertedRow) => {
       if (err) return callback(err);
@@ -131,7 +131,7 @@ function setupRoleCrudEvents(motherEmitter) {
       }
 
       // Build the update payload
-      const updatedData = { updated_at: new Date() };
+      const updatedData = { updated_at: new Date().toISOString() };
       if (newRoleName)    updatedData.role_name   = newRoleName;
       if (newDescription) updatedData.description = newDescription;
       if (newPermissions) updatedData.permissions = JSON.stringify(newPermissions);

--- a/BlogposterCMS/mother/modules/userManagement/userCrudEvents.js
+++ b/BlogposterCMS/mother/modules/userManagement/userCrudEvents.js
@@ -86,8 +86,8 @@ function setupUserCrudEvents(motherEmitter) {
         avatar_url  : avatarUrl   || null,
         bio         : bio         || null,
         token_version: 0,
-        created_at  : new Date(),
-        updated_at  : new Date()
+        created_at  : new Date().toISOString(),
+        updated_at  : new Date().toISOString()
       };
 
       // 3) Insert user
@@ -394,7 +394,7 @@ function setupUserCrudEvents(motherEmitter) {
 
     try {
       const dataToUpdate = {
-        updated_at: new Date()
+        updated_at: new Date().toISOString()
       };
       if (newUsername)     dataToUpdate.username     = newUsername;
       if (newEmail)        dataToUpdate.email        = newEmail;

--- a/BlogposterCMS/mother/modules/userManagement/userInitService.js
+++ b/BlogposterCMS/mother/modules/userManagement/userInitService.js
@@ -67,8 +67,8 @@ async function ensureDefaultRoles(motherEmitter, jwt) {
         is_system_role: true,
         description: 'System Admin Role',
         permissions: JSON.stringify({ canAccessEverything: true }),
-        created_at: new Date(),
-        updated_at: new Date()
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
       }
     }));
   }
@@ -83,8 +83,8 @@ async function ensureDefaultRoles(motherEmitter, jwt) {
         is_system_role: false,
         description: 'Default basic user role',
         permissions: JSON.stringify({}),
-        created_at: new Date(),
-        updated_at: new Date()
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
       }
     }));
   }

--- a/BlogposterCMS/mother/modules/userManagement/userService.js
+++ b/BlogposterCMS/mother/modules/userManagement/userService.js
@@ -121,8 +121,8 @@ function ensureDefaultRoles(motherEmitter, jwt, nonce) {
                   is_system_role: true,
                   description: 'System Admin Role',
                   permissions: JSON.stringify({ canAccessEverything: true }),
-                  created_at: new Date(),
-                  updated_at: new Date()
+                  created_at: new Date().toISOString(),
+                  updated_at: new Date().toISOString()
                 }
               },
               cb
@@ -142,8 +142,8 @@ function ensureDefaultRoles(motherEmitter, jwt, nonce) {
                   is_system_role: false,
                   description: 'Default basic user role',
                   permissions: JSON.stringify({}),
-                  created_at: new Date(),
-                  updated_at: new Date()
+                  created_at: new Date().toISOString(),
+                  updated_at: new Date().toISOString()
                 }
               },
               cb

--- a/BlogposterCMS/mother/modules/widgetManager/index.js
+++ b/BlogposterCMS/mother/modules/widgetManager/index.js
@@ -162,7 +162,7 @@ motherEmitter.on('createWidget', async (payload, callback) => {
         label:      label || '',
         content:    content || '',
         category:   category || '',
-        created_at: new Date()
+        created_at: new Date().toISOString()
       }
     }, (insertErr, result) => {
       if (insertErr) return callback(insertErr);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Timestamps now stored in UTC using `new Date().toISOString()` for all `created_at` and `updated_at` fields.
 - Ensured Mongo unique indexes are created foreground with retry logic for
   user, page and widget collections to avoid race-condition duplicates.
 - Fixed Mongo `SET_AS_START` to run within a transaction using


### PR DESCRIPTION
## Summary
- store created_at/updated_at timestamps in UTC across modules
- document UTC timestamp usage in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843f0cafdb483288a5aa79e7f4a412c