### PR TITLE
Add Mongo replica set env sample

### DIFF
--- a/BlogposterCMS/env.sample
+++ b/BlogposterCMS/env.sample
@@ -19,7 +19,9 @@ PG_ADMIN_DB=postgres_admin_db
 # Choose database type ('postgres', 'mongodb' or 'sqlite')
 CONTENT_DB_TYPE=postgres
 
-# MongoDB Connection URI
+# MongoDB Connection URI (use ?replicaSet=rs0 when running a replica set)
+# Example for a single-node replica set named "rs0":
+# MONGODB_URI=mongodb://localhost:27017/cms?replicaSet=rs0
 MONGODB_URI=mongodb://username:password@localhost:27017/admin
 
 # SQLite storage location (only used when CONTENT_DB_TYPE=sqlite)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Added example `MONGODB_URI` with `replicaSet` parameter in env.sample and
+  updated docs to clarify replica set usage.
+- Documented MongoDB replica set requirement for transaction-based modules to prevent startup failures.
 - Timestamps now stored in UTC using `new Date().toISOString()` for all `created_at` and `updated_at` fields.
 - Ensured Mongo unique indexes are created foreground with retry logic for
   user, page and widget collections to avoid race-condition duplicates.

--- a/docs/choosing_database_engine.md
+++ b/docs/choosing_database_engine.md
@@ -10,6 +10,14 @@ BlogposterCMS can use **PostgreSQL**, **MongoDB** or **SQLite** for storing cont
 ## MongoDB
 - Support is experimental and not yet thoroughly tested.
 - Only choose MongoDB if you are comfortable debugging potential issues.
+- **Replica Set required for transactions** – Some core modules use MongoDB
+  transactions (e.g. the Pages Manager when marking a start page). Transactions
+  only work when the database runs as a replica set or is accessed through a
+  `mongos` router. A standalone server will throw `Transaction numbers are only
+  allowed on a replica set member or mongos` and the module initialization fails.
+  Configure Mongo accordingly or disable transactions if you cannot run a
+  replica set. Your `MONGODB_URI` connection string should include the
+  `replicaSet=<name>` parameter, e.g. `mongodb://localhost:27017/cms?replicaSet=rs0`.
 
 ## SQLite
 - Suitable for lightweight setups or testing.


### PR DESCRIPTION
## Summary
- show example `MONGODB_URI` with `?replicaSet=rs0` in env.sample
- document replica set parameter in the database engine guide
- note the change in the changelog

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68440aa70870832898de8d0028e32ef9