### PR TITLE
Fix SELECT_MODULE_BY_NAME params handling

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
@@ -736,7 +736,8 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
     }
 
     case 'SELECT_MODULE_BY_NAME': {
-      const { moduleName } = (params[0] || {});
+      const p = Array.isArray(params) ? (params[0] || {}) : (params || {});
+      const { moduleName } = p;
       const doc = await db.collection('module_registry').findOne({
         module_name: moduleName
       });

--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/postgresPlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/postgresPlaceholders.js
@@ -712,12 +712,14 @@ switch (operation) {
     }
 
     case 'SELECT_MODULE_BY_NAME': {
-      const { moduleName } = (params[0] || {});
-      const { rows } = await client.query(`
-        SELECT module_name, module_info
+      const p = Array.isArray(params) ? (params[0] || {}) : (params || {});
+      const { moduleName } = p;
+      const { rows } = await client.query(
+        `SELECT module_name, module_info
         FROM "moduleloader"."module_registry"
-        WHERE module_name = $1
-      `, [moduleName]);
+        WHERE module_name = $1`,
+        [moduleName]
+      );
       return rows;
     }
     

--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/sqlitePlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/sqlitePlaceholders.js
@@ -623,12 +623,14 @@ case 'LIST_ACTIVE_GRAPES_MODULES': {
 }
 
 case 'SELECT_MODULE_BY_NAME': {
-  const moduleName = params?.moduleName ?? params?.[0];
-  const rows = await db.all(`
-    SELECT module_name, module_info
+  const p = Array.isArray(params) ? (params[0] || {}) : (params || {});
+  const { moduleName } = p;
+  const rows = await db.all(
+    `SELECT module_name, module_info
       FROM moduleloader_module_registry
-     WHERE module_name = ?;
-  `, [moduleName]);
+     WHERE module_name = ?;`,
+    [moduleName]
+  );
   return rows;
 }
 

--- a/BlogposterCMS/tests/selectModuleByName.test.js
+++ b/BlogposterCMS/tests/selectModuleByName.test.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+
+const { handleBuiltInPlaceholderPostgres } = require('../mother/modules/databaseManager/placeholders/postgresPlaceholders');
+const { handleBuiltInPlaceholderMongo } = require('../mother/modules/databaseManager/placeholders/mongoPlaceholders');
+const { handleBuiltInPlaceholderSqlite } = require('../mother/modules/databaseManager/placeholders/sqlitePlaceholders');
+
+async function runPostgres(params) {
+  const captured = {};
+  const client = {
+    query: async (sql, values) => {
+      captured.values = values;
+      return { rows: [] };
+    }
+  };
+  await handleBuiltInPlaceholderPostgres(client, 'SELECT_MODULE_BY_NAME', params);
+  return captured.values;
+}
+
+async function runMongo(params) {
+  let received;
+  const db = {
+    collection: () => ({
+      findOne: async (q) => {
+        received = q;
+        return null;
+      }
+    })
+  };
+  await handleBuiltInPlaceholderMongo(db, 'SELECT_MODULE_BY_NAME', params);
+  return received;
+}
+
+async function runSqlite(params) {
+  let received;
+  const db = {
+    all: async (sql, values) => {
+      received = values;
+      return [];
+    }
+  };
+  await handleBuiltInPlaceholderSqlite(db, 'SELECT_MODULE_BY_NAME', params);
+  return received;
+}
+
+test('SELECT_MODULE_BY_NAME extracts moduleName from params array and object', async () => {
+  const arrayParams = [{ moduleName: 'testMod' }];
+  const objectParams = { moduleName: 'testMod' };
+
+  assert.deepStrictEqual(await runPostgres(arrayParams), ['testMod']);
+  assert.deepStrictEqual(await runPostgres(objectParams), ['testMod']);
+
+  assert.deepStrictEqual(await runMongo(arrayParams), { module_name: 'testMod' });
+  assert.deepStrictEqual(await runMongo(objectParams), { module_name: 'testMod' });
+
+  assert.deepStrictEqual(await runSqlite(arrayParams), ['testMod']);
+  assert.deepStrictEqual(await runSqlite(objectParams), ['testMod']);
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fixed SQLite "SELECT_MODULE_BY_NAME" to accept array or object params like other drivers.
 - Added example `MONGODB_URI` with `replicaSet` parameter in env.sample and
   updated docs to clarify replica set usage.
 - Documented MongoDB replica set requirement for transaction-based modules to prevent startup failures.


### PR DESCRIPTION
## Summary
- normalize params handling in SELECT_MODULE_BY_NAME across DB drivers
- add regression test for SELECT_MODULE_BY_NAME
- update changelog

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684410796f20832894f359c5caf7ccc9