### PR TITLE
Fix passive touchstart event listeners

### DIFF
--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -82,10 +82,18 @@ function renderWidget(wrapper, def, code = null, lane = 'public') {
   };
   container.addEventListener('pointerdown', stop, true);
   container.addEventListener('mousedown', stop, true);
-  container.addEventListener('touchstart', stop, true);
+  container.addEventListener(
+    'touchstart',
+    stop,
+    { capture: true, passive: true }
+  );
   wrapper.addEventListener('pointerdown', stop, true);
   wrapper.addEventListener('mousedown', stop, true);
-  wrapper.addEventListener('touchstart', stop, true);
+  wrapper.addEventListener(
+    'touchstart',
+    stop,
+    { capture: true, passive: true }
+  );
   root.appendChild(container);
 
   if (code) {

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -141,10 +141,18 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     };
     container.addEventListener('pointerdown', stop, true);
     container.addEventListener('mousedown', stop, true);
-    container.addEventListener('touchstart', stop, true);
+    container.addEventListener(
+      'touchstart',
+      stop,
+      { capture: true, passive: true }
+    );
     content.addEventListener('pointerdown', stop, true);
     content.addEventListener('mousedown', stop, true);
-    content.addEventListener('touchstart', stop, true);
+    content.addEventListener(
+      'touchstart',
+      stop,
+      { capture: true, passive: true }
+    );
     root.appendChild(container);
 
     if (data) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Marked `touchstart` handlers as passive in builder and page renderers to avoid scroll-blocking warnings.
 - Fixed SQLite "SELECT_MODULE_BY_NAME" to accept array or object params like other drivers.
 - Fixed regression test by stubbing `db.run` in the SQLite placeholder test.
 - Added example `MONGODB_URI` with `replicaSet` parameter in env.sample and


### PR DESCRIPTION
## Summary
- avoid scroll blocking warnings by adding passive `touchstart` handlers in builderRenderer and pageRenderer
- document the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684414b635788328ba71ff50b3571f64