### PR TITLE
Fix missing meltdown error logs

### DIFF
--- a/BlogposterCMS/app.js
+++ b/BlogposterCMS/app.js
@@ -311,6 +311,7 @@ app.post('/api/meltdown', apiLimiter, async (req, res) => {
   // 4) Emit the event and return JSON
   motherEmitter.emit(eventName, payload, (err, data) => {
     if (err) {
+      console.error(`[MELTDOWN] Event "${eventName}" failed =>`, err.message);
       return res.status(500).json({ error: err.message });
     }
     return res.json({ eventName, data });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Marked `touchstart` handlers as passive in builder and page renderers to avoid scroll-blocking warnings.
+- Logged failed meltdown events to server console for easier debugging when layout saves fail.
 - Fixed SQLite "SELECT_MODULE_BY_NAME" to accept array or object params like other drivers.
 - Fixed regression test by stubbing `db.run` in the SQLite placeholder test.
 - Added example `MONGODB_URI` with `replicaSet` parameter in env.sample and


### PR DESCRIPTION
## Summary
- log meltdown event errors in server output
- document meltdown error logging in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684418f530488328966f4e0adee7757f