### PR TITLE
Fix Mongo builder layout save

### DIFF
--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -272,7 +272,9 @@ function ensureLayout(layout = {}, lane = 'public') {
       }
 
       const urlParams = new URLSearchParams(window.location.search);
-      const pageIdParam = parseInt(urlParams.get('pageId'), 10) || null;
+      // Pass page IDs as strings so MongoDB ObjectIds remain intact. Postgres
+      // will cast numeric strings automatically.
+      const pageIdParam = urlParams.get('pageId') || null;
 
       await initBuilder(sidebarEl, contentEl, pageIdParam);
 

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -578,7 +578,9 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
 
       const targetIds = pageId
         ? [pageId]
-        : Array.from(pageSelect?.selectedOptions || []).map(o => parseInt(o.value, 10));
+        // Keep IDs as strings so MongoDB ObjectIds are preserved. Postgres
+        // automatically casts numeric strings to integers.
+        : Array.from(pageSelect?.selectedOptions || []).map(o => o.value);
       for (const id of targetIds) {
         await meltdownEmit('saveLayoutForViewport', {
           jwt: window.ADMIN_TOKEN,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Marked `touchstart` handlers as passive in builder and page renderers to avoid scroll-blocking warnings.
+- Fixed builder layout saves on MongoDB by preserving string page IDs.
+- Kept builder pageId query params as strings so Mongo ObjectIds save correctly without affecting Postgres.
 - Logged failed meltdown events to server console for easier debugging when layout saves fail.
 - Fixed SQLite "SELECT_MODULE_BY_NAME" to accept array or object params like other drivers.
 - Fixed regression test by stubbing `db.run` in the SQLite placeholder test.


### PR DESCRIPTION
## Summary
- keep IDs as strings in builderRenderer and pageRenderer to support MongoDB
- note pageId string handling in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68441baf069883289f34d827f1c73112