### PR TITLE
Fix Mongo page edit links

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
@@ -348,7 +348,10 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
                                 .find({ parent_id: parentId })
                                 .sort({ created_at: -1 })
                                 .toArray();
-      return childPages;
+      return childPages.map(p => ({
+        ...p,
+        id: p.id || (p._id ? p._id.toHexString() : undefined)
+      }));
     }
   
   
@@ -360,7 +363,10 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
                               .find({})
                               .sort({ _id: -1 })
                               .toArray();
-      return allPages;
+      return allPages.map(p => ({
+        ...p,
+        id: p.id || (p._id ? p._id.toHexString() : undefined)
+      }));
     }
 
     case 'GET_PAGES_BY_LANE': {
@@ -388,6 +394,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
         { $sort: { created_at: -1 } },
         {
           $project: {
+            _id: 1,
             slug: 1,
             status: 1,
             seo_image: 1,
@@ -409,8 +416,10 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
           }
         }
       ]).toArray();
-
-      return pages;
+      return pages.map(p => ({
+        ...p,
+        id: p.id || (p._id ? p._id.toHexString() : undefined)
+      }));
     }
   
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Mongo page queries now include an `id` field so admin edit links work.
 - Marked `touchstart` handlers as passive in builder and page renderers to avoid scroll-blocking warnings.
 - Fixed builder layout saves on MongoDB by preserving string page IDs.
 - Kept builder pageId query params as strings so Mongo ObjectIds save correctly without affecting Postgres.


### PR DESCRIPTION
## Summary
- ensure Mongo placeholders return `id` field so admin edit links function
- document fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68441e66d8e08328b2c4df6830f3fc2d