### PR TITLE
Fix meltdown logging CodeQL alert

### DIFF
--- a/BlogposterCMS/app.js
+++ b/BlogposterCMS/app.js
@@ -311,7 +311,8 @@ app.post('/api/meltdown', apiLimiter, async (req, res) => {
   // 4) Emit the event and return JSON
   motherEmitter.emit(eventName, payload, (err, data) => {
     if (err) {
-      console.error(`[MELTDOWN] Event "${eventName}" failed =>`, err.message);
+      const safeEvent = String(eventName).replace(/[\n\r]/g, '');
+      console.error('[MELTDOWN] Event "%s" failed => %s', safeEvent, err.message);
       return res.status(500).json({ error: err.message });
     }
     return res.json({ eventName, data });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Sanitized meltdown event logs to prevent format string injection.
 - Mongo page queries now include an `id` field so admin edit links work.
 - Marked `touchstart` handlers as passive in builder and page renderers to avoid scroll-blocking warnings.
 - Fixed builder layout saves on MongoDB by preserving string page IDs.


### PR DESCRIPTION
## Summary
- sanitize meltdown event names before logging
- document the log sanitization in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684421f129808328ba27a40c3a85ddb7