### PR TITLE
Fix admin route page id handling

### DIFF
--- a/BlogposterCMS/app.js
+++ b/BlogposterCMS/app.js
@@ -503,6 +503,9 @@ app.get('/admin/*', pageLimiter, csrfProtection, async (req, res, next) => {
     if (/^\d+$/.test(maybeId)) {
       pageId = parseInt(maybeId, 10) || null;
       rawSlug = rawSlug.slice(0, lastSlash);
+    } else if (/^[a-f0-9]{24}$/i.test(maybeId)) {
+      pageId = maybeId.toLowerCase();
+      rawSlug = rawSlug.slice(0, lastSlash);
     }
   }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fixed admin wildcard route to parse hex page IDs for MongoDB.
 - Mongo page queries now include an `id` field so admin edit links work.
 - Marked `touchstart` handlers as passive in builder and page renderers to avoid scroll-blocking warnings.
 - Fixed builder layout saves on MongoDB by preserving string page IDs.


### PR DESCRIPTION
## Summary
- support hex page IDs in admin wildcard route
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68442210b3688328ad42de1d79693ba8