### PR TITLE
Update modules settings styling

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/modulesListWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/modulesListWidget.js
@@ -10,11 +10,25 @@ export async function render(el) {
     });
     const modules = Array.isArray(res) ? res : (res?.data ?? []);
 
+    const card = document.createElement('div');
+    card.className = 'modules-list-card page-list-card';
+
+    const titleBar = document.createElement('div');
+    titleBar.className = 'modules-title-bar page-title-bar';
+
+    const title = document.createElement('div');
+    title.className = 'modules-title page-title';
+    title.textContent = 'Modules';
+
+    titleBar.appendChild(title);
+    card.appendChild(titleBar);
+
     const list = document.createElement('ul');
-    list.className = 'modules-list';
+    list.className = 'modules-list page-list';
 
     if (!modules.length) {
-      const empty = document.createElement('li');
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
       empty.textContent = 'No modules found.';
       list.appendChild(empty);
     } else {
@@ -28,8 +42,10 @@ export async function render(el) {
       });
     }
 
+    card.appendChild(list);
+
     el.innerHTML = '';
-    el.appendChild(list);
+    el.appendChild(card);
   } catch (err) {
     el.innerHTML = `<div class="error">Failed to load modules: ${err.message}</div>`;
   }

--- a/BlogposterCMS/public/assets/scss/pages/_modules.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_modules.scss
@@ -1,0 +1,25 @@
+// Styles for Modules List widget
+
+.modules-list-card {
+  @extend .page-list-card;
+}
+
+.modules-title-bar {
+  @extend .page-title-bar;
+}
+
+.modules-title {
+  @extend .page-title;
+}
+
+.modules-list {
+  @extend .page-list;
+}
+
+.modules-list .empty-state {
+  @extend %page-list-empty-state;
+}
+
+.modules-list li {
+  @extend %page-list-item;
+}

--- a/BlogposterCMS/public/assets/scss/site.scss
+++ b/BlogposterCMS/public/assets/scss/site.scss
@@ -15,6 +15,7 @@
 @import 'pages/pages';
 @import 'pages/media';
 @import 'pages/settings';
+@import 'pages/modules';
 @import 'components/builder';
 @import 'components/heading-widget';
 @import 'components/page-editor';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Styled modules settings widget to match page manager.
 - Hardened dummyModule logging and made callbacks optional.
 - Fixed dummyModule initialization by using payload-based `performDbOperation` calls.
 


### PR DESCRIPTION
## Summary
- style modules settings widget to reuse page manager look
- import new modules styles in main SCSS
- document styling change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68454a7d5db88328a2dcf987282b121a