### PR TITLE
Document dummyModule and improve template comments

### DIFF
--- a/BlogposterCMS/modules/dummyModule/index.js
+++ b/BlogposterCMS/modules/dummyModule/index.js
@@ -1,34 +1,40 @@
 /**
  * mother/modules/dummyModule/index.js
  *
- * Ein Minimal-Beispiel, wie ein NO-UI-Modul aufgebaut sein kann.
- * 
- * - Keine Express-Routen, da wir KEIN `app` übergeben.
- * - Nur motherEmitter => DB, Hooks, apiCoreRequest.
+ * Minimal example of how a NO-UI module can look.
+ *
+ * Use this file as a template for your own community modules. The
+ * comments walk you through every available hook and demonstrate how to
+ * trigger safe database operations via the meltdown event bus.
+ *
+ * - No Express routes because we do NOT receive an `app` instance.
+ * - Only `motherEmitter` is provided for DB, hooks and apiCoreRequest.
  */
 
 'use strict';
 
 module.exports = {
     /**
-     * Wird vom moduleLoader aufgerufen:
+     * Called by the moduleLoader:
      *    await dummyModule.initialize({ motherEmitter });
      *
-     * Hier darf man:
-     *   - Events registrieren
-     *   - "apiCoreRequest" aufrufen
-     *   - "performDbOperation" / "createDatabase" auslösen
+     * Inside this function you may:
+     *   - register events
+     *   - call "apiCoreRequest"
+     *   - trigger "performDbOperation" / "createDatabase"
      */
     async initialize({ motherEmitter }) {
       console.log('[DUMMY MODULE] Initializing dummyModule...');
   
-      // 1) Beispiel-Hook: pagePublished
+      // 1) Example hook: pagePublished
       motherEmitter.on('pagePublished', (pageObj) => {
         const safeId = String(pageObj.id).replace(/[\n\r]/g, '');
         const safeTitle = String(pageObj.title || '').replace(/[\n\r]/g, '');
         console.log('[DUMMY MODULE] Detected pagePublished => id=%s title=%s', safeId, safeTitle);
-        // => Z.B. wir rufen eine (erfundene) externe API
-        // => motherEmitter.emit('apiCoreRequest', { service, action, payload }, cb)
+        // Example: call a fictional external API.
+        // Tokens or other secrets should NEVER live in the code.
+        // Use environment variables instead.
+        // motherEmitter.emit('apiCoreRequest', { service, action, payload }, cb)
         motherEmitter.emit(
           'apiCoreRequest',
           {
@@ -46,8 +52,8 @@ module.exports = {
         );
       });
   
-      // 2) Beispiel: DB-Operation
-      //    Angenommen wir wollen ein "dummy table" anlegen (hier sehr vereinfacht):
+      // 2) Example: database operation
+      //    Here we create a simple "dummy table" if it doesn't exist.
       const createTableSQL = `
         CREATE TABLE IF NOT EXISTS dummy_dummytable (
           id SERIAL PRIMARY KEY,
@@ -72,11 +78,11 @@ module.exports = {
         }
       );
   
-      // 3) Beispiel: Wir lauschen auf custom-event "dummyAction"
+      // 3) Example: listen for the custom event "dummyAction"
       motherEmitter.on('dummyAction', (payload, callback) => {
         console.log('[DUMMY MODULE] got dummyAction');
-        // => Mach irgendwas
-        // => z.B. Insert in unsere Dummy-Tabelle
+        // => Do something here
+        // => For example insert data into our dummy table
         const insertSQL = 'INSERT INTO dummy_dummytable(data) VALUES($1)';
         motherEmitter.emit(
           'performDbOperation',
@@ -94,8 +100,10 @@ module.exports = {
         );
       });
   
-      // => Fertig
+      // => Done
       console.log('[DUMMY MODULE] dummyModule initialized. (No UI)');
+      // Copy this module and adjust the events
+      // to integrate your own features into BlogposterCMS.
     }
   };
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ El Psy Kongroo
 ## [Unreleased]
 - Hardened dummyModule logging and made callbacks optional.
 - Fixed dummyModule initialization by using payload-based `performDbOperation` calls.
+- Documented dummyModule usage and added developer-friendly comments.
+- Translated dummyModule comments to English and expanded template guide.
 
 ## [0.4.2] – 2025-06-07
 - Fixed admin wildcard route to parse hex page IDs for MongoDB.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Looking for actual instructions? Start with the [documentation index](docs/index
 
 Fancy tricks like dynamic login strategies, the meltdown event bus, or safe dependency loading are explained there too. Basically, if you’re looking for details, consult the docs.
 
+For a minimal example of how to build your own module, check out [`modules/dummyModule`](BlogposterCMS/modules/dummyModule) and its [documentation](docs/modules/dummyModule.md).
+
 BlogposterCMS tries to be secure first, developer friendly second, and user friendly third. If you spot a hole or have a question, open an issue—or a pull request if you’re feeling brave. Have fun!
 
 ## License

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -56,4 +56,5 @@ important security notes.
 - [unifiedSettings](modules/unifiedSettings.md)
 - [userManagement](modules/userManagement.md)
 - [widgetManager](modules/widgetManager.md)
+- [dummyModule](modules/dummyModule.md)
 - [Choosing a Database Engine](choosing_database_engine.md)

--- a/docs/modules/dummyModule.md
+++ b/docs/modules/dummyModule.md
@@ -1,0 +1,27 @@
+# dummyModule
+
+The `dummyModule` is a minimal no‑UI module used as a learning template.
+It demonstrates how community modules interact with BlogposterCMS using the meltdown event bus.
+The module's `apiDefinition.json` shows how to declare external services and actions.
+
+## Startup
+- Loaded from `modules/dummyModule` when present.
+- Only requires the `motherEmitter` object during initialization.
+
+## Purpose
+- Logs whenever a page is published using a fictional external service.
+- Shows how to perform simple database operations.
+- Listens for a custom `dummyAction` event that inserts data into a table.
+
+## Listened Events
+- `pagePublished`
+- `dummyAction`
+
+## Security Notes
+- Sanitises page titles and IDs before logging.
+- Never store real API tokens in `apiDefinition.json`—use environment variables instead.
+
+Use this module as a starting point for your own experiments. Copy the folder,
+update the service definitions and event names in `apiDefinition.json`, and wire
+your own handlers to the events you care about. Environment variables are the
+preferred way to inject API tokens or other secrets.


### PR DESCRIPTION
## Summary
- add docs entry for dummyModule
- reference dummyModule in module list and README
- expand comments in dummyModule for new module authors
- note the update in the changelog
- translate comments to English and extend dummy module docs

## Testing
- `npm test --silent`
- `npm run placeholder-parity --silent`


------
https://chatgpt.com/codex/tasks/task_e_68454a162bc48328b48b8c83281f0639