### PR TITLE
Implement widget options menu in builder

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -312,6 +312,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       };
     });
     el.appendChild(btn);
+    return btn;
   }
 
   let allWidgets = [];
@@ -412,6 +413,65 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       if (pageId) saveCurrentLayout();
     });
     el.appendChild(btn);
+    return btn;
+  }
+
+  function attachOptionsMenu(el, widgetDef, editBtn) {
+    const menuBtn = document.createElement('button');
+    menuBtn.className = 'widget-menu';
+    menuBtn.innerHTML = window.featherIcon ? window.featherIcon('more-vertical') :
+      '<img src="/assets/icons/more-vertical.svg" alt="menu" />';
+
+    const menu = document.createElement('div');
+    menu.className = 'widget-options-menu';
+    menu.innerHTML = `
+      <button class="menu-edit"><img src="/assets/icons/edit.svg" class="icon" alt="edit" /> Edit Code</button>
+      <button class="menu-copy"><img src="/assets/icons/copy.svg" class="icon" alt="duplicate" /> Duplicate</button>
+      <button class="menu-template"><img src="/assets/icons/package.svg" class="icon" alt="template" /> Save as Template</button>
+      <button class="menu-lock"><img src="/assets/icons/lock.svg" class="icon" alt="lock" /> Lock Position</button>
+      <button class="menu-snap"><img src="/assets/icons/grid.svg" class="icon" alt="snap" /> Snap to Grid</button>
+      <button class="menu-global"><img src="/assets/icons/globe.svg" class="icon" alt="global" /> Set as Global Widget</button>
+    `;
+    menu.style.display = 'none';
+
+    menuBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      menu.style.display = menu.style.display === 'block' ? 'none' : 'block';
+    });
+
+    menu.querySelector('.menu-edit').onclick = () => { editBtn.click(); menu.style.display = 'none'; };
+    menu.querySelector('.menu-copy').onclick = () => {
+      const clone = el.cloneNode(true);
+      clone.dataset.instanceId = genId();
+      gridEl.appendChild(clone);
+      grid.makeWidget(clone);
+      attachRemoveButton(clone);
+      const cEditBtn = attachEditButton(clone, widgetDef);
+      attachOptionsMenu(clone, widgetDef, cEditBtn);
+      renderWidget(clone, widgetDef);
+      menu.style.display = 'none';
+    };
+    menu.querySelector('.menu-template').onclick = () => {
+      alert('Save as Template not implemented');
+      menu.style.display = 'none';
+    };
+    menu.querySelector('.menu-lock').onclick = () => {
+      const locked = el.getAttribute('gs-locked') === 'true';
+      el.setAttribute('gs-locked', (!locked).toString());
+      grid.update(el, { locked: !locked });
+      menu.style.display = 'none';
+    };
+    menu.querySelector('.menu-snap').onclick = () => {
+      grid.update(el, { x: Math.round(+el.getAttribute('gs-x')), y: Math.round(+el.getAttribute('gs-y')) });
+      menu.style.display = 'none';
+    };
+    menu.querySelector('.menu-global').onclick = () => {
+      alert('Global Widget feature not implemented');
+      menu.style.display = 'none';
+    };
+
+    el.appendChild(menuBtn);
+    el.appendChild(menu);
   }
 
 
@@ -437,7 +497,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     content.innerHTML = `${getWidgetIcon(widgetDef)}<span>${widgetDef.metadata?.label || widgetDef.id}</span>`;
     wrapper.appendChild(content);
     attachRemoveButton(wrapper);
-    attachEditButton(wrapper, widgetDef);
+    const editBtn = attachEditButton(wrapper, widgetDef);
+    attachOptionsMenu(wrapper, widgetDef, editBtn);
     gridEl.appendChild(wrapper);
     grid.makeWidget(wrapper);
     renderWidget(wrapper, widgetDef);
@@ -477,7 +538,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     content.innerHTML = `${getWidgetIcon(widgetDef)}<span>${widgetDef.metadata?.label || widgetDef.id}</span>`;
     wrapper.appendChild(content);
     attachRemoveButton(wrapper);
-    attachEditButton(wrapper, widgetDef);
+    const editBtn2 = attachEditButton(wrapper, widgetDef);
+    attachOptionsMenu(wrapper, widgetDef, editBtn2);
     gridEl.appendChild(wrapper);
     grid.makeWidget(wrapper);
 

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -133,7 +133,7 @@
 .grid-stack-item .widget-remove {
   position: absolute;
   top: 2px;
-  right: 2px;
+  left: 2px;
   background: transparent;
   border: none;
   padding: 2px;
@@ -144,9 +144,13 @@
 }
 
 .grid-stack-item .widget-edit {
+  display: none;
+}
+
+.grid-stack-item .widget-menu {
   position: absolute;
   top: 2px;
-  right: 28px;
+  right: 2px;
   background: transparent;
   border: none;
   padding: 2px;
@@ -156,14 +160,39 @@
   transition: opacity 0.2s ease;
 }
 
+
+.grid-stack-item:hover .widget-menu,
 .grid-stack-item:hover .widget-remove {
   opacity: 1;
   pointer-events: auto;
 }
 
-.grid-stack-item:hover .widget-edit {
-  opacity: 1;
-  pointer-events: auto;
+.widget-options-menu {
+  position: absolute;
+  top: 24px;
+  right: 2px;
+  background: var(--color-white);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: var(--shadow-card);
+  display: none;
+  z-index: 60;
+}
+
+.widget-options-menu button {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+}
+
+.widget-options-menu button:hover {
+  background: var(--color-light-gray, #f0f0f0);
 }
 
 .widget-code-editor {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Builder widgets now have a three-dot menu with edit and duplicate actions, and the remove button moved to the left.
 - Updated README: linked to bp-cli, collapsed screenshots in a details section, added GridStack reference and license header note.
 - Improved README structure with an alpha badge, quick install snippet and more descriptive screenshot alt text.
 - Added a CONTRIBUTING guide and linked it from the README.


### PR DESCRIPTION
## Summary
- add `attachOptionsMenu` in builder renderer
- move remove button to left
- add menu button to widgets for edit/duplicate/etc
- hide edit icon and update styles for new menu
- document update in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847b12998dc8328ab16e9c1f3aacb67