### PR TITLE
Fix builder options menu position

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -433,10 +433,37 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       <button class="menu-global"><img src="/assets/icons/globe.svg" class="icon" alt="global" /> Set as Global Widget</button>
     `;
     menu.style.display = 'none';
+    document.body.appendChild(menu);
+
+    function hideMenu() {
+      menu.style.display = 'none';
+      document.removeEventListener('click', outsideHandler);
+    }
+
+    function outsideHandler(ev) {
+      if (!menu.contains(ev.target) && ev.target !== menuBtn) hideMenu();
+    }
 
     menuBtn.addEventListener('click', e => {
       e.stopPropagation();
-      menu.style.display = menu.style.display === 'block' ? 'none' : 'block';
+      if (menu.style.display === 'block') {
+        hideMenu();
+        return;
+      }
+      menu.style.display = 'block';
+      menu.style.visibility = 'hidden';
+      const rect = menuBtn.getBoundingClientRect();
+      menu.style.top = `${rect.top}px`;
+      const spaceRight = window.innerWidth - rect.right;
+      const spaceLeft = rect.left;
+      if (spaceRight >= menu.offsetWidth || spaceRight >= spaceLeft) {
+        menu.style.left = `${rect.right + 4}px`;
+      } else {
+        const left = rect.left - menu.offsetWidth - 4;
+        menu.style.left = `${Math.max(0, left)}px`;
+      }
+      menu.style.visibility = '';
+      document.addEventListener('click', outsideHandler);
     });
 
     menu.querySelector('.menu-edit').onclick = () => { editBtn.click(); menu.style.display = 'none'; };
@@ -471,7 +498,6 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     };
 
     el.appendChild(menuBtn);
-    el.appendChild(menu);
   }
 
 

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -168,15 +168,15 @@
 }
 
 .widget-options-menu {
-  position: absolute;
-  top: 24px;
-  right: 2px;
+  position: fixed;
+  top: 0;
+  left: 0;
   background: var(--color-white);
   border: 1px solid #ccc;
   border-radius: 4px;
   box-shadow: var(--shadow-card);
   display: none;
-  z-index: 60;
+  z-index: 1000;
 }
 
 .widget-options-menu button {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Options menu in the builder now appears outside widgets for better visibility.
 - Builder widgets now have a three-dot menu with edit and duplicate actions, and the remove button moved to the left.
 - Updated README: linked to bp-cli, collapsed screenshots in a details section, added GridStack reference and license header note.
 - Improved README structure with an alpha badge, quick install snippet and more descriptive screenshot alt text.


### PR DESCRIPTION
## Summary
- ensure builder options menu opens outside widget
- style options menu as fixed overlay
- document change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847bf4e15a48328814587a19bc5e2df