### PR TITLE
Remove Quill from builder HTML editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Removed Quill from the builder widget HTML editor; now a simple textarea is used.
 - Options menu in the builder now appears outside widgets for better visibility.
 - Builder widgets now have a three-dot menu with edit and duplicate actions, and the remove button moved to the left.
 - Updated README: linked to bp-cli, collapsed screenshots in a details section, added GridStack reference and license header note.


### PR DESCRIPTION
## Summary
- remove Quill dependency from builder HTML editor overlay
- use a simple `<textarea>` instead
- document the change in `CHANGELOG.md`

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_6847c28f07848328b8172d1a699ceef1