### PR TITLE
Add dynamic Quill editor to text block widget

### DIFF
--- a/BlogposterCMS/public/assets/js/quillEditor.js
+++ b/BlogposterCMS/public/assets/js/quillEditor.js
@@ -3,6 +3,8 @@ export function initQuill(element, options = {}) {
     console.error('[quillEditor] Quill library not loaded');
     return null;
   }
+  element.style.width = '100%';
+  element.style.height = '100%';
   const defaults = { theme: 'snow' };
   return new Quill(element, Object.assign({}, defaults, options));
 }

--- a/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
@@ -2,17 +2,26 @@
 // dynamically using an absolute URL so the import succeeds in that case.
 const quillUrl = new URL('/assets/js/quillEditor.js', document.baseURI).href;
 
+function sanitizeHtml(html) {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  div.querySelectorAll('script').forEach(el => el.remove());
+  return div.innerHTML;
+}
+
 export async function render(el, ctx = {}) {
   const { initQuill } = await import(quillUrl);
   const container = document.createElement('div');
   container.className = 'text-block-widget';
+  container.style.width = '100%';
+  container.style.height = '100%';
   container.innerHTML = ctx?.metadata?.label || '<p>Sample text block</p>';
 
   if (ctx.jwt) {
     const quill = initQuill(container);
     if (quill) {
       quill.on('text-change', async () => {
-        const html = quill.root.innerHTML.trim();
+        const html = sanitizeHtml(quill.root.innerHTML.trim());
         try {
           await window.meltdownEmit('updateWidget', {
             jwt: ctx.jwt,

--- a/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
@@ -1,0 +1,10 @@
+.text-block-widget,
+.text-block-widget .ql-container {
+  width: 100%;
+  height: 100%;
+}
+
+.widget-code-editor .editor-html {
+  width: 100%;
+  height: 120px;
+}

--- a/BlogposterCMS/public/assets/scss/site.scss
+++ b/BlogposterCMS/public/assets/scss/site.scss
@@ -19,4 +19,5 @@
 @import 'components/builder';
 @import 'components/heading-widget';
 @import 'components/page-editor';
+@import 'components/text-block-widget';
 @import 'pages/users';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Moved text block widget styles to SCSS for easier maintenance.
+- Text block widget now uses a Quill editor with dynamic sizing and HTML
+  sanitation.
 - Options menu in the builder now appears outside widgets for better visibility.
 - Builder widgets now have a three-dot menu with edit and duplicate actions, and the remove button moved to the left.
 - Updated README: linked to bp-cli, collapsed screenshots in a details section, added GridStack reference and license header note.


### PR DESCRIPTION
## Summary
- use Quill for `textBlockWidget`
- sanitize HTML before saving
- ensure editor elements are full width/height
- move widget styles from CSS to SCSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847c307f33883289debedbc58ad30e7