### PR TITLE
Fix builder widgets placeholder reset

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/public/buttonWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/buttonWidget.js
@@ -1,6 +1,7 @@
-export function render(el){
-  const btn=document.createElement('button');
-  btn.textContent='Click me';
-  btn.addEventListener('click',()=>alert('Button clicked!'));
+export function render(el, ctx = {}) {
+  const btn = document.createElement('button');
+  // Start with no label to preserve user edits
+  btn.textContent = ctx?.metadata?.label || '';
+  btn.addEventListener('click', () => alert('Button clicked!'));
   el.appendChild(btn);
 }

--- a/BlogposterCMS/public/assets/plainspace/public/counterWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/counterWidget.js
@@ -1,11 +1,11 @@
 // mother/modules/plainSpace/assets/counterWidget.js
 // Example of a simple public widget
 
-export function render(containerEl) {
+export function render(containerEl, ctx = {}) {
     // minimal example with a counter
     containerEl.innerHTML = `
       <div>
-        <p>Counter Widget: <span x-text="count"></span></p>
+        <p>${ctx?.metadata?.label || ''}<span x-text="count"></span></p>
         <button @click="count++">Increment</button>
       </div>
     `;

--- a/BlogposterCMS/public/assets/plainspace/public/headingWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/headingWidget.js
@@ -7,7 +7,8 @@ function sanitizeLevel(lvl) {
 
 export function render(el, ctx = {}) {
   const defaultLevel = sanitizeLevel(ctx?.metadata?.category || 'h3');
-  const defaultText = ctx?.metadata?.label || 'Section Heading';
+  // Remove placeholder text so widgets start empty
+  const defaultText = ctx?.metadata?.label || '';
 
   let level = defaultLevel;
   let heading = document.createElement(level);

--- a/BlogposterCMS/public/assets/plainspace/public/heroBannerWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/heroBannerWidget.js
@@ -1,7 +1,8 @@
 // public/assets/plainspace/public/heroBannerWidget.js
-export function render(el){
+export function render(el, ctx = {}) {
     const h = document.createElement('h2');
-    h.textContent='🚀 Welcome to our site!';
+    // Avoid hard coded greeting that overwrites edits
+    h.textContent = ctx?.metadata?.label || '';
     el.appendChild(h);
-  }
+}
   

--- a/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
@@ -15,7 +15,8 @@ export async function render(el, ctx = {}) {
   container.className = 'text-block-widget';
   container.style.width = '100%';
   container.style.height = '100%';
-  container.innerHTML = ctx?.metadata?.label || '<p>Sample text block</p>';
+  // Avoid overriding custom content by omitting placeholder text
+  container.innerHTML = ctx?.metadata?.label || '';
 
   if (ctx.jwt) {
     const quill = initQuill(container);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Removed placeholder text from all public widgets to preserve user edits.
 - Moved text block widget styles to SCSS for easier maintenance.
 - Text block widget now uses a Quill editor with dynamic sizing and HTML
   sanitation.


### PR DESCRIPTION
## Summary
- remove hardcoded placeholder text from public widgets
- update changelog

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_6847cdbfc2988328abd75a2318abf79b