### PR TITLE
Fix builder JS preview

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -244,7 +244,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       }
       htmlEl.value = codeData.html || '';
       overlay.querySelector('.editor-css').value = codeData.css || '';
-      overlay.querySelector('.editor-js').value = codeData.js || codeData.sourceJs || '';
+      jsEl.value = codeData.js || '';
+      overlay.defaultJs = codeData.sourceJs || '';
       overlay.currentSelector = codeData.selector || '';
 
       function pickElement() {
@@ -285,8 +286,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
         const instId = el.dataset.instanceId;
         codeMap[instId] = {
           html: htmlEl.value,
-          css: wrapCss(overlay.querySelector('.editor-css').value, overlay.currentSelector),
-          js: overlay.querySelector('.editor-js').value,
+          css: wrapCss(cssEl.value, overlay.currentSelector),
+          js: jsEl.value,
           selector: overlay.currentSelector
         };
         overlay.style.display = 'none';
@@ -300,7 +301,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
         delete codeMap[instId];
         htmlEl.value = '';
         overlay.querySelector('.editor-css').value = '';
-        overlay.querySelector('.editor-js').value = codeData.sourceJs || '';
+        overlay.querySelector('.editor-js').value = overlay.defaultJs || '';
         overlay.currentSelector = '';
         overlay.updateRender && overlay.updateRender();
         if (pageId) saveCurrentLayout();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed widget code editor so unsaved JS doesn't overwrite HTML when closing the
+  builder edit overlay.
 - Removed placeholder text from all public widgets to preserve user edits.
 - Moved text block widget styles to SCSS for easier maintenance.
 - Text block widget now uses a Quill editor with dynamic sizing and HTML


### PR DESCRIPTION
## Summary
- ensure builder editor doesn't auto-run default JS when opening widgets
- persist user HTML/CSS/JS properly when closing the editor
- note the fix in `CHANGELOG.md`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6847d219dc8c83289127dff1df4c6e68