### PR TITLE
Fix text block widget editing

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
@@ -25,14 +25,22 @@ export async function render(el, ctx = {}) {
   container.className = 'text-block-widget';
   container.style.width = '100%';
   container.style.height = '100%';
-  container.innerHTML = ctx?.metadata?.label || '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>';
+  const defaultText = '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>';
+  const initial = ctx?.metadata?.label;
+  const safeHtml = sanitizeHtml(!initial || initial === 'Text Block' ? defaultText : initial);
+  container.innerHTML = safeHtml;
 
   async function enableEdit() {
     if (!ctx.jwt || quillInstance) {
       return;
     }
     if (!initQuill) {
-      ({ initQuill } = await import(quillUrl));
+      try {
+        ({ initQuill } = await import(quillUrl));
+      } catch (err) {
+        console.error('[textBlockWidget] editor load failed', err);
+        return;
+      }
     }
     quillInstance = initQuill(container);
     if (!quillInstance) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed text block widget not showing the Lorem Ipsum placeholder when first
+  added and ensured the Quill editor initializes on click.
 - Text block widget now displays a Lorem Ipsum placeholder and activates the
   Quill editor on click. Edits are sanitized before being stored.
 - Improved text block widget sanitization and only load the Quill editor when


### PR DESCRIPTION
## Summary
- ensure default text placeholder is shown for new text blocks
- handle failed Quill imports gracefully
- changelog entry

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_6847d9de262c83288ab3dc2c0df31271