### PR TITLE
Scope theme styling to public and builder

### DIFF
--- a/BlogposterCMS/app.js
+++ b/BlogposterCMS/app.js
@@ -85,6 +85,9 @@ const jwtExpiryConfig = {
   low   : process.env.JWT_EXPIRY_LOW
 };
 
+const ACTIVE_THEME = (process.env.ACTIVE_THEME || 'default')
+  .replace(/[^a-zA-Z0-9_-]/g, '') || 'default';
+
 //───────────────────────────────────────────────────────────────────────────
 // Load local secret overrides (optional .secrets.js files)
 //───────────────────────────────────────────────────────────────────────────
@@ -546,6 +549,7 @@ app.get('/admin/*', pageLimiter, csrfProtection, async (req, res, next) => {
         window.PAGE_ID     = ${JSON.stringify(pageId ?? page.id)};
         window.PAGE_SLUG   = ${JSON.stringify(slug)};
         window.ADMIN_TOKEN = ${JSON.stringify(adminJwt)};
+        window.ACTIVE_THEME = ${JSON.stringify(ACTIVE_THEME)};
         window.NONCE       = ${JSON.stringify(nonce)};
       </script>
     </head>`;
@@ -687,6 +691,7 @@ app.get('/:slug?', pageLimiter, async (req, res, next) => {
       window.PAGE_SLUG = ${JSON.stringify(slugToUse)};
       window.LANE    = ${JSON.stringify(lane)};
       window.PUBLIC_TOKEN = ${JSON.stringify(token)};
+      window.ACTIVE_THEME = ${JSON.stringify(ACTIVE_THEME)};
       window.NONCE  = ${JSON.stringify(nonce)};
     </script>`;
     html = html.replace('</head>', inject + '</head>');

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -25,8 +25,13 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     contentSummary: 'activity'
   };
 
-  function getGlobalCssUrl() {
-    return '/assets/css/site.css';
+  function getCssUrls() {
+    const theme = window.ACTIVE_THEME || 'default';
+    return [
+      '/assets/css/gridstack.min.css',
+      '/assets/css/site.css',
+      `/themes/${theme}/theme.css`
+    ];
   }
 
   const codeMap = {};
@@ -110,11 +115,13 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     while (root.firstChild) {
       root.removeChild(root.firstChild);
     }
-    const globalCss = getGlobalCssUrl();
-
-    const style = document.createElement('style');
-    style.textContent = `@import url('${globalCss}');`;
-    root.appendChild(style);
+    const cssUrls = getCssUrls();
+    cssUrls.slice(0, 2).forEach(u => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = u;
+      root.appendChild(link);
+    });
 
     const container = document.createElement('div');
     container.className = 'widget-container';
@@ -151,6 +158,10 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
         customStyle.textContent = data.css;
         root.appendChild(customStyle);
       }
+      const themeLink = document.createElement('link');
+      themeLink.rel = 'stylesheet';
+      themeLink.href = cssUrls[2];
+      root.appendChild(themeLink);
       if (data.html) {
         container.innerHTML = data.html;
       }
@@ -170,6 +181,11 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     import(widgetDef.codeUrl)
       .then(m => m.render?.(container, ctx))
       .catch(err => console.error('[Builder] widget import error', err));
+
+    const themeLink = document.createElement('link');
+    themeLink.rel = 'stylesheet';
+    themeLink.href = cssUrls[2];
+    root.appendChild(themeLink);
   }
 
   function attachEditButton(el, widgetDef) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Builder widget CSS now loads gridstack and admin styles before the active theme
+  to avoid layout conflicts.
+- Active theme CSS is now injected into public pages and builder grid only.
+- Builder widgets preview using theme styles without affecting the admin UI.
 - Fixed text block widget not showing the Lorem Ipsum placeholder when first
   added and ensured the Quill editor initializes on click.
 - Text block widget now displays a Lorem Ipsum placeholder and activates the


### PR DESCRIPTION
## Summary
- inject active theme value into admin and public pages
- load theme CSS inside builder widgets
- make builder CSS load gridstack and admin styles before the active theme
- document the change in `CHANGELOG.md`

## Testing
- `npm --prefix BlogposterCMS test`


------
https://chatgpt.com/codex/tasks/task_e_6847dbdc89d8832891bd080c3ba0c13a