### PR TITLE
Fix builder widget code URL resolution

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -174,7 +174,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     if (window.ADMIN_TOKEN) {
       ctx.jwt = window.ADMIN_TOKEN;
     }
-    import(widgetDef.codeUrl)
+    const codeUrl = new URL(widgetDef.codeUrl, document.baseURI).href;
+    import(codeUrl)
       .then(m => m.render?.(container, ctx))
       .catch(err => console.error('[Builder] widget import error', err));
 
@@ -247,7 +248,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
 
       if (!codeData.sourceJs) {
         try {
-          const resp = await fetch(widgetDef.codeUrl);
+          const resp = await fetch(new URL(widgetDef.codeUrl, document.baseURI).href);
           codeData.sourceJs = await resp.text();
         } catch (err) {
           console.error('[Builder] fetch widget source error', err);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Resolved blank widgets when opening the code editor by loading widget scripts using absolute URLs.
 - Fixed builder widgets showing blank when CSS was injected before widget content.
 - Text block widget now loads the Quill library and styles on demand so editing
   works in sandboxed widgets.


### PR DESCRIPTION
## Summary
- ensure widget JS imports use absolute URLs so editing works
- document fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847e3e875dc83289ca75a6596f9ab48