### PR TITLE
Refine widget overlay layers

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -121,6 +121,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
 
     const container = document.createElement('div');
     container.className = 'widget-container';
+    const overlay = document.createElement('div');
+    overlay.className = 'builder-overlay';
     // Prevent GridStack from initiating a drag when interacting
     // with form controls inside widgets. Attach the handler on both the
     // container and the grid item content to catch events before GridStack
@@ -147,17 +149,18 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       { capture: true, passive: true }
     );
     root.appendChild(container);
+    root.appendChild(overlay);
 
     if (data) {
+      const themeLink = document.createElement('link');
+      themeLink.rel = 'stylesheet';
+      themeLink.href = cssUrls[1];
+      root.appendChild(themeLink);
       if (data.css) {
         const customStyle = document.createElement('style');
         customStyle.textContent = data.css;
         root.appendChild(customStyle);
       }
-      const themeLink = document.createElement('link');
-      themeLink.rel = 'stylesheet';
-      themeLink.href = cssUrls[1];
-      root.appendChild(themeLink);
       if (data.html) {
         container.innerHTML = data.html;
       }
@@ -512,6 +515,21 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     el.appendChild(menuBtn);
   }
 
+  function attachOverlayHandlers(el) {
+    const show = () => el.classList.add('overlay-visible');
+    const hide = () => el.classList.remove('overlay-visible');
+
+    el.addEventListener('mouseenter', show);
+    el.addEventListener('mouseleave', hide);
+    el.addEventListener(
+      'touchstart',
+      () => {
+        el.classList.toggle('overlay-visible');
+      },
+      { passive: true }
+    );
+  }
+
 
   initialLayout.forEach(item => {
     const widgetDef = allWidgets.find(w => w.id === item.widgetId);
@@ -537,6 +555,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     attachRemoveButton(wrapper);
     const editBtn = attachEditButton(wrapper, widgetDef);
     attachOptionsMenu(wrapper, widgetDef, editBtn);
+    attachOverlayHandlers(wrapper);
     gridEl.appendChild(wrapper);
     grid.makeWidget(wrapper);
     renderWidget(wrapper, widgetDef);
@@ -578,6 +597,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     attachRemoveButton(wrapper);
     const editBtn2 = attachEditButton(wrapper, widgetDef);
     attachOptionsMenu(wrapper, widgetDef, editBtn2);
+    attachOverlayHandlers(wrapper);
     gridEl.appendChild(wrapper);
     grid.makeWidget(wrapper);
 

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -167,6 +167,21 @@
   pointer-events: auto;
 }
 
+.grid-stack-item .builder-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.05);
+  pointer-events: none;
+  opacity: 0;
+  z-index: 10;
+  transition: opacity 0.2s ease;
+}
+
+.grid-stack-item.overlay-visible .builder-overlay,
+.grid-stack-item:hover .builder-overlay {
+  opacity: 1;
+}
+
 .widget-options-menu {
   position: fixed;
   top: 0;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Added two-layer widget rendering: overlay styles from site.css show on hover or
+  tap, while theme and in-editor styles apply above widget content.
+- Refactored builder public lane widgets with a hover overlay using site.css
+  while theme and custom widget styles load with proper priority.
 - Resolved blank widgets when opening the code editor by loading widget scripts using absolute URLs.
 - Fixed builder widgets showing blank when CSS was injected before widget content.
 - Text block widget now loads the Quill library and styles on demand so editing


### PR DESCRIPTION
## Summary
- add toggle overlay on touch in builderRenderer
- revert compiled CSS to avoid modifying built assets
- document two-layer widget overlay in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847e5b7aef08328bacac31aa1c52773