### PR TITLE
Add widget click lock

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -512,6 +512,17 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     el.appendChild(menuBtn);
   }
 
+  function attachLockOnClick(el) {
+    el.addEventListener('click', e => {
+      if (e.target.closest('.widget-menu, .widget-edit, .widget-remove')) {
+        return;
+      }
+      if (el.getAttribute('gs-locked') === 'true') return;
+      el.setAttribute('gs-locked', 'true');
+      grid.update(el, { locked: true });
+    });
+  }
+
 
   initialLayout.forEach(item => {
     const widgetDef = allWidgets.find(w => w.id === item.widgetId);
@@ -537,6 +548,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     attachRemoveButton(wrapper);
     const editBtn = attachEditButton(wrapper, widgetDef);
     attachOptionsMenu(wrapper, widgetDef, editBtn);
+    attachLockOnClick(wrapper);
     gridEl.appendChild(wrapper);
     grid.makeWidget(wrapper);
     renderWidget(wrapper, widgetDef);
@@ -578,6 +590,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     attachRemoveButton(wrapper);
     const editBtn2 = attachEditButton(wrapper, widgetDef);
     attachOptionsMenu(wrapper, widgetDef, editBtn2);
+    attachLockOnClick(wrapper);
     gridEl.appendChild(wrapper);
     grid.makeWidget(wrapper);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widgets now lock on click in the builder so they can be edited globally.
 - Resolved blank widgets when opening the code editor by loading widget scripts using absolute URLs.
 - Fixed builder widgets showing blank when CSS was injected before widget content.
 - Text block widget now loads the Quill library and styles on demand so editing


### PR DESCRIPTION
## Summary
- lock builder widgets on click so editing is possible globally
- document this behavior in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847ec9f4914832885209a1ff5dd70da