### PR TITLE
Fix theme css not applied in builder

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -154,10 +154,9 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
         customStyle.textContent = data.css;
         root.appendChild(customStyle);
       }
-      const themeLink = document.createElement('link');
-      themeLink.rel = 'stylesheet';
-      themeLink.href = cssUrls[1];
-      root.appendChild(themeLink);
+      const themeStyle = document.createElement('style');
+      themeStyle.textContent = `@import url('${cssUrls[1]}');`;
+      root.appendChild(themeStyle);
       if (data.html) {
         container.innerHTML = data.html;
       }
@@ -179,10 +178,9 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       .then(m => m.render?.(container, ctx))
       .catch(err => console.error('[Builder] widget import error', err));
 
-    const themeLink = document.createElement('link');
-    themeLink.rel = 'stylesheet';
-    themeLink.href = cssUrls[1];
-    root.appendChild(themeLink);
+    const themeStyle = document.createElement('style');
+    themeStyle.textContent = `@import url('${cssUrls[1]}');`;
+    root.appendChild(themeStyle);
   }
 
   function attachEditButton(el, widgetDef) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ El Psy Kongroo
 
 ## [Unreleased]
 - Widgets now lock on click in the builder so they can be edited globally.
+- Fixed theme styles not applying in the builder by importing the active theme stylesheet inside widget shadow roots.
 - Resolved blank widgets when opening the code editor by loading widget scripts using absolute URLs.
 - Fixed builder widgets showing blank when CSS was injected before widget content.
 - Text block widget now loads the Quill library and styles on demand so editing


### PR DESCRIPTION
## Summary
- render theme styles inside widget shadow roots in the builder
- document fix in changelog

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f05e21a48328860b98611231dfbc