### PR TITLE
Implement widget auto-unlock and lock indicator

### DIFF
--- a/BlogposterCMS/public/assets/css/site.css
+++ b/BlogposterCMS/public/assets/css/site.css
@@ -1099,6 +1099,17 @@ body.builder-mode #main-header {
   display: none;
 }
 
+.grid-stack-item[gs-locked="true"]::after {
+  content: "";
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  width: 16px;
+  height: 16px;
+  background: url('/assets/icons/lock.svg') no-repeat center/contain;
+  pointer-events: none;
+}
+
 .heading-widget {
   display: flex;
   align-items: center;

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -34,6 +34,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   }
 
   const codeMap = {};
+  let activeLockedEl = null;
   const genId = () => `w${Math.random().toString(36).slice(2,8)}`;
 
   function extractCssProps(el) {
@@ -357,6 +358,17 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   // Enable floating mode for easier widget placement in the builder
   const grid = GridStack.init({ float: true, cellHeight: 5, columnWidth: 5, column: 64 }, gridEl);
 
+  document.addEventListener('click', e => {
+    if (!activeLockedEl) return;
+    if (e.target.closest('.grid-stack-item') === activeLockedEl ||
+        e.target.closest('.widget-menu, .widget-edit, .widget-remove')) {
+      return;
+    }
+    activeLockedEl.setAttribute('gs-locked', 'false');
+    grid.update(activeLockedEl, { locked: false });
+    activeLockedEl = null;
+  });
+
   function getCurrentLayout() {
     const items = Array.from(gridEl.querySelectorAll('.grid-stack-item'));
     return items.map(el => ({
@@ -517,9 +529,14 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       if (e.target.closest('.widget-menu, .widget-edit, .widget-remove')) {
         return;
       }
-      if (el.getAttribute('gs-locked') === 'true') return;
+      if (activeLockedEl && activeLockedEl !== el) {
+        activeLockedEl.setAttribute('gs-locked', 'false');
+        grid.update(activeLockedEl, { locked: false });
+      }
+      activeLockedEl = el;
       el.setAttribute('gs-locked', 'true');
       grid.update(el, { locked: true });
+      e.stopPropagation();
     });
   }
 

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -247,3 +247,14 @@ body.builder-mode #top-header,
 body.builder-mode #main-header {
   display: none;
 }
+
+.grid-stack-item[gs-locked="true"]::after {
+  content: '';
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  width: 16px;
+  height: 16px;
+  background: url('/assets/icons/lock.svg') no-repeat center/contain;
+  pointer-events: none;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Builder widgets unlock when clicking outside and show a lock icon while active.
 - Widgets now lock on click in the builder so they can be edited globally.
 - Resolved blank widgets when opening the code editor by loading widget scripts using absolute URLs.
 - Fixed builder widgets showing blank when CSS was injected before widget content.


### PR DESCRIPTION
## Summary
- add global click handler to auto-unlock widgets
- show lock icon when a widget is locked
- update builder SCSS/CSS with lock indicator styles
- document the change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847f13ea35c8328a7dc755fd4de4a92