### PR TITLE
Fix builder theme and quill styling

### DIFF
--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -21,6 +21,17 @@ function ensureGlobalStyle(lane) {
   link.href = url;
   link.dataset.globalStyle = lane;
   document.head.appendChild(link);
+
+  if (lane === 'admin' && document.body.classList.contains('builder-mode')) {
+    const theme = window.ACTIVE_THEME || 'default';
+    if (!document.querySelector('link[data-builder-theme]')) {
+      const themeLink = document.createElement('link');
+      themeLink.rel = 'stylesheet';
+      themeLink.href = `/themes/${theme}/theme.css`;
+      themeLink.dataset.builderTheme = '';
+      document.head.appendChild(themeLink);
+    }
+  }
 }
 
 function executeJs(code, wrapper, root) {

--- a/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
@@ -54,6 +54,13 @@ export async function render(el, ctx = {}) {
           link.href = quillCssUrl;
           document.head.appendChild(link);
         }
+        const root = el.getRootNode();
+        if (root instanceof ShadowRoot && !root.querySelector(`link[href="${quillCssUrl}"]`)) {
+          const link = document.createElement('link');
+          link.rel = 'stylesheet';
+          link.href = quillCssUrl;
+          root.appendChild(link);
+        }
         ({ initQuill } = await import(quillEditorUrl));
       } catch (err) {
         console.error('[textBlockWidget] editor load failed', err);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Theme stylesheet now loads globally when the builder is active so widgets use
+  site colors and fonts.
+- Quill editor styles are injected into widget shadow roots for consistent text
+  editing.
 - Locking now sets GridStack's `noMove` and `noResize` flags to completely disable widget movement while locked.
 - Lock icon overlay now uses SCSS with a higher z-index so it always appears above widgets.
 - Locked widgets now display a lock icon overlay in place of the resize arrow and cannot be dragged or resized.


### PR DESCRIPTION
## Summary
- load the active theme globally when the builder is active
- inject quill editor CSS inside widget shadow roots
- document the styling fixes in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847fbe88ac48328bee879680fa9af12