### PR TITLE
Fix widget update spamming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Debounced text block widget updates to avoid rate limiting while typing.
+
 - Theme stylesheet now loads globally when the builder is active so widgets use
   site colors and fonts.
 - Quill editor styles are injected into widget shadow roots for consistent text


### PR DESCRIPTION
## Summary
- debounce text-change events in textBlockWidget to prevent rate limit errors
- document the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847fe9773448328b5eeb033aa272293