### PR TITLE
Sanitize widget instance content

### DIFF
--- a/BlogposterCMS/mother/modules/plainSpace/plainSpaceService.js
+++ b/BlogposterCMS/mother/modules/plainSpace/plainSpaceService.js
@@ -2,6 +2,7 @@
 // Because obviously we can’t keep these little helpers in index.js. That would be too straightforward.
 
 require('dotenv').config();
+const { sanitizeHtml } = require('../../utils/contentSanitizer');
 const { onceCallback } = require('../../emitters/motherEmitter');
 const { hasPermission } = require('../userManagement/permissionUtils');
 
@@ -397,6 +398,7 @@ function registerPlainSpaceEvents(motherEmitter) {
       if (!jwt || !instanceId) {
         return cb(new Error('[plainSpace] Invalid payload in saveWidgetInstance.'));
       }
+      const sanitizedContent = sanitizeHtml(content);
       motherEmitter.emit(
         'dbUpdate',
         {
@@ -404,7 +406,7 @@ function registerPlainSpaceEvents(motherEmitter) {
           moduleName: MODULE,
           moduleType: 'core',
           table: '__rawSQL__',
-          data: { rawSQL: 'UPSERT_WIDGET_INSTANCE', params: { instanceId, content } }
+          data: { rawSQL: 'UPSERT_WIDGET_INSTANCE', params: { instanceId, content: sanitizedContent } }
         },
         cb
       );

--- a/BlogposterCMS/mother/utils/contentSanitizer.js
+++ b/BlogposterCMS/mother/utils/contentSanitizer.js
@@ -2,8 +2,20 @@
 
 function sanitizeHtml(html) {
   if (typeof html !== 'string') return '';
-  let sanitized = html.replace(/<script[^>]*>.*?<\/script>/gis, '');
-  sanitized = sanitized.replace(/ on\w+=("[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+  let sanitized = html;
+  let previous;
+  const scriptRegex = /<script\b[^>]*>.*?<\s*\/\s*script\s*>/gis;
+  do {
+    previous = sanitized;
+    sanitized = sanitized.replace(scriptRegex, '');
+  } while (sanitized !== previous);
+
+  const handlerRegex = /\son\w+=("[^"]*"|'[^']*'|[^\s>]+)/gi;
+  do {
+    previous = sanitized;
+    sanitized = sanitized.replace(handlerRegex, '');
+  } while (sanitized !== previous);
+
   return sanitized;
 }
 

--- a/BlogposterCMS/mother/utils/contentSanitizer.js
+++ b/BlogposterCMS/mother/utils/contentSanitizer.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function sanitizeHtml(html) {
+  if (typeof html !== 'string') return '';
+  let sanitized = html.replace(/<script[^>]*>.*?<\/script>/gis, '');
+  sanitized = sanitized.replace(/ on\w+=("[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+  return sanitized;
+}
+
+module.exports = { sanitizeHtml };

--- a/BlogposterCMS/mother/utils/contentSanitizer.js
+++ b/BlogposterCMS/mother/utils/contentSanitizer.js
@@ -1,22 +1,17 @@
 'use strict';
 
+const DOMPurify = require('dompurify');
+const { JSDOM } = require('jsdom');
+
+let purifyInstance;
+
 function sanitizeHtml(html) {
   if (typeof html !== 'string') return '';
-  let sanitized = html;
-  let previous;
-  const scriptRegex = /<script\b[^>]*>.*?<\s*\/\s*script\s*>/gis;
-  do {
-    previous = sanitized;
-    sanitized = sanitized.replace(scriptRegex, '');
-  } while (sanitized !== previous);
-
-  const handlerRegex = /\son\w+=("[^"]*"|'[^']*'|[^\s>]+)/gi;
-  do {
-    previous = sanitized;
-    sanitized = sanitized.replace(handlerRegex, '');
-  } while (sanitized !== previous);
-
-  return sanitized;
+  if (!purifyInstance) {
+    const window = new JSDOM('').window;
+    purifyInstance = DOMPurify(window);
+  }
+  return purifyInstance.sanitize(html);
 }
 
 module.exports = { sanitizeHtml };

--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -26,7 +26,9 @@
         "mongodb": "^6.10.0",
         "pg": "^8.13.1",
         "sqlite3": "^5.1.7",
-        "uuid": "^11.0.3"
+        "uuid": "^11.0.3",
+        "dompurify": "^3.2.6",
+        "jsdom": "^26.1.0"
     },
     "devDependencies": {
         "jest": "^29.7.0",

--- a/BlogposterCMS/tests/contentSanitizer.test.js
+++ b/BlogposterCMS/tests/contentSanitizer.test.js
@@ -2,8 +2,8 @@ const assert = require('assert');
 const { sanitizeHtml } = require('../mother/utils/contentSanitizer');
 
 test('content sanitizer removes scripts and event handlers', () => {
-  const dirty = '<div onclick="evil()"><script>alert(1)</script>Hello</div>';
+  const dirty = '<div onclick="evil()"><script>alert(1)</script><script >x()</script >Hello</div>';
   const clean = sanitizeHtml(dirty);
-  assert(!clean.includes('<script>'), 'script tag not removed');
+  assert(!/<script/i.test(clean), 'script tag not removed');
   assert(!/onclick=/i.test(clean), 'event handler not removed');
 });

--- a/BlogposterCMS/tests/contentSanitizer.test.js
+++ b/BlogposterCMS/tests/contentSanitizer.test.js
@@ -6,4 +6,5 @@ test('content sanitizer removes scripts and event handlers', () => {
   const clean = sanitizeHtml(dirty);
   assert(!/<script/i.test(clean), 'script tag not removed');
   assert(!/onclick=/i.test(clean), 'event handler not removed');
+  assert(/Hello/.test(clean), 'content missing after sanitization');
 });

--- a/BlogposterCMS/tests/contentSanitizer.test.js
+++ b/BlogposterCMS/tests/contentSanitizer.test.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { sanitizeHtml } = require('../mother/utils/contentSanitizer');
+
+test('content sanitizer removes scripts and event handlers', () => {
+  const dirty = '<div onclick="evil()"><script>alert(1)</script>Hello</div>';
+  const clean = sanitizeHtml(dirty);
+  assert(!clean.includes('<script>'), 'script tag not removed');
+  assert(!/onclick=/i.test(clean), 'event handler not removed');
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Improved HTML sanitizer to repeatedly remove script tags and event handlers.
 - Sanitized widget content in plainSpaceService.saveWidgetInstance before database writes.
 - Text block widget content is stored per instance so seeded widgets remain unchanged.
 - Debounced text block widget updates to avoid rate limiting while typing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Sanitized widget content in plainSpaceService.saveWidgetInstance before database writes.
 - Text block widget content is stored per instance so seeded widgets remain unchanged.
 - Debounced text block widget updates to avoid rate limiting while typing.
 - Theme stylesheet now loads globally when the builder is active so widgets use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
-- Improved HTML sanitizer to repeatedly remove script tags and event handlers.
+- Replaced custom HTML sanitizer with DOMPurify for more robust security.
 - Sanitized widget content in plainSpaceService.saveWidgetInstance before database writes.
 
 - Widget instance API now enforces `plainspace.widgetInstance` permission.


### PR DESCRIPTION
## Summary
- add reusable HTML sanitizer
- sanitize widget instance content before DB write
- test the sanitizer
- document security improvement in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68480abbe498832888b04f74788ab93a