### PR TITLE
Add permission check for widgetInstance events

### DIFF
--- a/BlogposterCMS/mother/modules/plainSpace/plainSpaceService.js
+++ b/BlogposterCMS/mother/modules/plainSpace/plainSpaceService.js
@@ -393,9 +393,12 @@ function registerPlainSpaceEvents(motherEmitter) {
   // 7) saveWidgetInstance
   motherEmitter.on('saveWidgetInstance', (payload, cb) => {
     try {
-      const { jwt, instanceId, content } = payload || {};
+      const { jwt, instanceId, content, decodedJWT } = payload || {};
       if (!jwt || !instanceId) {
         return cb(new Error('[plainSpace] Invalid payload in saveWidgetInstance.'));
+      }
+      if (decodedJWT && !hasPermission(decodedJWT, 'plainspace.widgetInstance')) {
+        return cb(new Error('Forbidden – missing permission: plainspace.widgetInstance'));
       }
       motherEmitter.emit(
         'dbUpdate',
@@ -416,9 +419,12 @@ function registerPlainSpaceEvents(motherEmitter) {
   // 8) getWidgetInstance
   motherEmitter.on('getWidgetInstance', (payload, cb) => {
     try {
-      const { jwt, instanceId } = payload || {};
+      const { jwt, instanceId, decodedJWT } = payload || {};
       if (!jwt || !instanceId) {
         return cb(new Error('[plainSpace] Invalid payload in getWidgetInstance.'));
+      }
+      if (decodedJWT && !hasPermission(decodedJWT, 'plainspace.widgetInstance')) {
+        return cb(new Error('Forbidden – missing permission: plainspace.widgetInstance'));
       }
       motherEmitter.emit(
         'dbSelect',

--- a/BlogposterCMS/tests/plainSpacePermissions.test.js
+++ b/BlogposterCMS/tests/plainSpacePermissions.test.js
@@ -1,0 +1,66 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+const EventEmitter = require('events');
+
+function onceWrap(cb) {
+  let called = false;
+  return (...args) => {
+    if (called) return;
+    called = true;
+    if (typeof cb === 'function') cb(...args);
+  };
+}
+
+function loadService() {
+  const base = path.resolve(__dirname, '../mother/modules/plainSpace');
+  const code = fs.readFileSync(path.join(base, 'plainSpaceService.js'), 'utf8');
+  function customRequire(name) {
+    if (name === 'dotenv') return { config: () => {} };
+    if (name === '../../emitters/motherEmitter') {
+      return { onceCallback: onceWrap };
+    }
+    if (name.startsWith('./') || name.startsWith('../')) {
+      return require(path.join(base, name));
+    }
+    return require(name);
+  }
+  const sandbox = { module: {}, exports: {}, require: customRequire, console };
+  vm.runInNewContext(code, sandbox, { filename: 'plainSpaceService.js' });
+  return sandbox.module.exports;
+}
+
+test('widget instance events respect permissions', async () => {
+  const { registerPlainSpaceEvents } = loadService();
+  const em = new EventEmitter();
+  registerPlainSpaceEvents(em);
+
+  let updates = 0;
+  let selects = 0;
+
+  em.on('dbUpdate', (payload, cb) => { updates++; cb(null, { ok: true }); });
+  em.on('dbSelect', (payload, cb) => { selects++; cb(null, [{ content: 'x' }]); });
+
+  const okJWT = { permissions: { plainspace: { widgetInstance: true } } };
+
+  await new Promise((res, rej) => {
+    em.emit('saveWidgetInstance', { jwt: 't', instanceId: '1', content: 'c', decodedJWT: okJWT }, err => err ? rej(err) : res());
+  });
+  assert.strictEqual(updates, 1);
+
+  await new Promise(resolve => {
+    em.emit('saveWidgetInstance', { jwt: 't', instanceId: '1', content: 'c', decodedJWT: {} }, err => { assert(err); resolve(); });
+  });
+  assert.strictEqual(updates, 1);
+
+  await new Promise((res, rej) => {
+    em.emit('getWidgetInstance', { jwt: 't', instanceId: '1', decodedJWT: okJWT }, (err, data) => err ? rej(err) : res(data));
+  });
+  assert.strictEqual(selects, 1);
+
+  await new Promise(resolve => {
+    em.emit('getWidgetInstance', { jwt: 't', instanceId: '1', decodedJWT: {} }, err => { assert(err); resolve(); });
+  });
+  assert.strictEqual(selects, 1);
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widget instance API now enforces `plainspace.widgetInstance` permission.
 - Text block widget content is stored per instance so seeded widgets remain unchanged.
 - Debounced text block widget updates to avoid rate limiting while typing.
 - Theme stylesheet now loads globally when the builder is active so widgets use


### PR DESCRIPTION
## Summary
- secure widget instance events in `plainSpaceService`
- add tests covering widget instance permission checks
- document permission requirement in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68480aca39988328862b752ce5a8a185