### PR TITLE
Fix widget locking on resize in builder

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -524,6 +524,9 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
 
   function attachLockOnClick(el) {
     el.addEventListener('click', e => {
+      if (!e.target.closest('.grid-stack-item-content')) {
+        return;
+      }
       if (e.target.closest('.widget-menu, .widget-edit, .widget-remove')) {
         return;
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Builder widgets no longer lock when using resize handles; only clicks on widget content toggle locking.
 - Fixed plainSpace widget instance database operations across all engines.
 - Widget instance API now enforces `plainspace.widgetInstance` permission.
 - Text block widget content is stored per instance so seeded widgets remain unchanged.


### PR DESCRIPTION
## Summary
- prevent locking when clicking resize handles
- document the behavior in the changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684929be00408328aba544f90817c3a1