### PR TITLE
Fix text block editor closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Text block editor now closes when clicking outside and uses an empty placeholder.
 - Builder widgets no longer lock when using resize handles; only clicks on widget content toggle locking.
 - Fixed plainSpace widget instance database operations across all engines.
 - Widget instance API now enforces `plainspace.widgetInstance` permission.


### PR DESCRIPTION
## Summary
- hide the text block editor when clicking outside
- remove placeholder dots by setting an empty Quill placeholder
- document the change in the changelog

## Testing
- `npm test --silent`
- `npm run placeholder-parity --silent`


------
https://chatgpt.com/codex/tasks/task_e_68492d1f3290832892a106c4c64363a7