### PR TITLE
Throttle text block saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Increased text block auto-save delay to 1.5s and skip identical saves to reduce API load.
 - Added "Layouts" admin page with a layout templates widget.
 - Text block editor now closes when clicking outside and uses an empty placeholder.
 - Builder widgets no longer lock when using resize handles; only clicks on widget content toggle locking.


### PR DESCRIPTION
## Summary
- reduce frequency of text block widget saves
- skip unchanged saves for the text block widget
- document auto-save change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68493393ffc8832886ce6d71c1cc2e34