### PR TITLE
Improve layout template previews

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
@@ -1184,6 +1184,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
             lane: d.lane,
             viewport: d.viewport,
             layout_json: d.layoutArr || [],
+            preview_path: d.previewPath || null,
             updated_at: new Date().toISOString()
           }
         },
@@ -1202,7 +1203,7 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
     const d = params[0] || {};
     const docs = await db.collection('plainspace_layout_templates')
         .find({ lane: d.lane })
-        .project({ name: 1, _id: 0 })
+        .project({ name: 1, preview_path: 1, _id: 0 })
         .sort({ name: 1 })
         .toArray();
     return docs;

--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/sqlitePlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/sqlitePlaceholders.js
@@ -1004,6 +1004,7 @@ case 'INIT_PLAINSPACE_LAYOUT_TEMPLATES': {
       lane        TEXT NOT NULL,
       viewport    TEXT NOT NULL,
       layout_json TEXT NOT NULL,
+      preview_path TEXT,
       updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
     );
   `);
@@ -1027,14 +1028,15 @@ case 'UPSERT_PLAINSPACE_LAYOUT_TEMPLATE': {
   const d = params?.[0] ?? {};
   await db.run(`
     INSERT INTO plainspace_layout_templates
-      (name, lane, viewport, layout_json, updated_at)
-    VALUES (?,?,?,?,CURRENT_TIMESTAMP)
+      (name, lane, viewport, layout_json, preview_path, updated_at)
+    VALUES (?,?,?,?,?,CURRENT_TIMESTAMP)
     ON CONFLICT(name) DO UPDATE SET
       lane        = excluded.lane,
       viewport    = excluded.viewport,
       layout_json = excluded.layout_json,
+      preview_path= excluded.preview_path,
       updated_at  = CURRENT_TIMESTAMP;
-  `, [d.name, d.lane, d.viewport, JSON.stringify(d.layoutArr ?? [])]);
+  `, [d.name, d.lane, d.viewport, JSON.stringify(d.layoutArr ?? []), d.previewPath ?? null]);
   return { success: true };
 }
 
@@ -1050,7 +1052,7 @@ case 'GET_PLAINSPACE_LAYOUT_TEMPLATE': {
 case 'GET_PLAINSPACE_LAYOUT_TEMPLATE_NAMES': {
   const { lane } = params?.[0] ?? {};
   const rows = await db.all(`
-    SELECT name FROM plainspace_layout_templates
+    SELECT name, preview_path FROM plainspace_layout_templates
      WHERE lane = ?
      ORDER BY name ASC;
   `, [lane]);

--- a/BlogposterCMS/mother/modules/plainSpace/plainSpaceService.js
+++ b/BlogposterCMS/mother/modules/plainSpace/plainSpaceService.js
@@ -298,7 +298,7 @@ function registerPlainSpaceEvents(motherEmitter) {
   // 4) saveLayoutTemplate
   motherEmitter.on('saveLayoutTemplate', (payload, cb) => {
     try {
-      const { jwt, name, lane, viewport, layout, decodedJWT } = payload || {};
+      const { jwt, name, lane, viewport, layout, previewPath, decodedJWT } = payload || {};
       if (!jwt || !name || !lane || !viewport || !Array.isArray(layout)) {
         return cb(new Error('[plainSpace] Invalid payload in saveLayoutTemplate.'));
       }
@@ -314,7 +314,7 @@ function registerPlainSpaceEvents(motherEmitter) {
           table: '__rawSQL__',
           data: {
             rawSQL: 'UPSERT_PLAINSPACE_LAYOUT_TEMPLATE',
-            params: { name, lane, viewport, layoutArr: layout }
+            params: { name, lane, viewport, layoutArr: layout, previewPath }
           }
         },
         cb
@@ -381,7 +381,7 @@ function registerPlainSpaceEvents(motherEmitter) {
         },
         (err, rows = []) => {
           if (err) return cb(err);
-          const templates = rows.map(r => r.name);
+          const templates = rows.map(r => ({ name: r.name, previewPath: r.preview_path || '' }));
           cb(null, { templates });
         }
       );

--- a/BlogposterCMS/public/assets/scss/pages/_layouts.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_layouts.scss
@@ -14,6 +14,17 @@
   @extend .page-filters;
 }
 
+.layout-actions-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+
+.add-layout-btn {
+  @extend .add-page-btn;
+}
+
 .layout-list {
   @extend .page-list;
 }
@@ -28,18 +39,69 @@
 
 .layout-item {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
 }
 
 .layout-preview {
-  width: 100%;
-  height: 80px;
+  width: 100px;
+  height: 70px;
   background: #f6f6f6;
   border-radius: 6px;
+  object-fit: cover;
 }
 
-.use-layout-btn {
-  margin-top: 4px;
+.layout-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.layout-name-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.layout-name {
+  font-family: var(--font-body);
+  font-size: 1.04rem;
+  color: #181818;
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.layout-actions {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.layout-actions .icon {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  fill: #888;
+  cursor: pointer;
+  opacity: 0.72;
+  transition: fill 0.16s, opacity 0.14s, transform 0.14s;
+  &:hover {
+    fill: #ff00ff;
+    opacity: 1;
+    transform: scale(1.13);
+  }
+}
+
+.layout-usage {
+  font-size: 0.85rem;
+  color: #555;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Layout template previews now stored via `preview_path`; widget shows preview images.
+- Layout templates widget now includes a create button and rearranged filters below it.
 - Added "Layouts" admin page with a layout templates widget.
 - Text block editor now closes when clicking outside and uses an empty placeholder.
 - Builder widgets no longer lock when using resize handles; only clicks on widget content toggle locking.


### PR DESCRIPTION
## Summary
- store preview image path in layout template tables
- extend API to handle preview paths
- show preview images in layout template widget
- sanitize layout item rendering
- document preview support in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849332322088328a9f1a7cf198ea569