### PR TITLE
Add notification hub

### DIFF
--- a/BlogposterCMS/mother/modules/notificationManager/index.js
+++ b/BlogposterCMS/mother/modules/notificationManager/index.js
@@ -2,7 +2,8 @@
  * mother/modules/notificationManager/index.js
  */
 const notificationEmitter = require('../../emitters/notificationEmitter');
-const { loadIntegrations } = require('./notificationManagerService');
+const { loadIntegrations, getRecentNotifications } = require('./notificationManagerService');
+const { onceCallback } = require('../../emitters/motherEmitter');
 
 module.exports = {
   async initialize({ motherEmitter, app, isCore, jwt }) {
@@ -39,6 +40,20 @@ module.exports = {
         } catch (err) {
           console.error(`[NOTIFICATION MANAGER] Integration "${name}" error =>`, err.message);
         }
+      }
+    });
+
+    motherEmitter.on('getRecentNotifications', (payload, cb) => {
+      const callback = onceCallback(cb);
+      try {
+        const { jwt, limit = 10 } = payload || {};
+        if (!jwt) {
+          return callback(new Error('[NOTIFICATION MANAGER] getRecentNotifications => missing jwt.'));
+        }
+        const list = getRecentNotifications(limit);
+        callback(null, list);
+      } catch (err) {
+        callback(err);
       }
     });
 

--- a/BlogposterCMS/public/admin.html
+++ b/BlogposterCMS/public/admin.html
@@ -56,6 +56,7 @@
 
   <!-- Top header icon actions -->
   <script type="module" src="/assets/js/topHeaderActions.js"></script>
+  <script type="module" src="/assets/js/notificationHub.js"></script>
   <!-- Content header actions -->
   <script type="module" src="/assets/js/contentHeaderActions.js"></script>
 

--- a/BlogposterCMS/public/assets/js/notificationHub.js
+++ b/BlogposterCMS/public/assets/js/notificationHub.js
@@ -1,0 +1,54 @@
+export default function initNotificationHub() {
+  const logo = document.querySelector('.top-header .logo');
+  if (!logo || logo.dataset.bound) return;
+  logo.dataset.bound = 'true';
+
+  const hub = document.getElementById('notification-hub');
+  if (!hub) return;
+  const list = hub.querySelector('ul');
+
+  async function loadNotifications() {
+    try {
+      const data = await window.meltdownEmit('getRecentNotifications', {
+        jwt: window.ADMIN_TOKEN,
+        moduleName: 'notificationManager',
+        moduleType: 'core',
+        limit: 5
+      });
+      list.innerHTML = '';
+      (data || []).forEach(n => {
+        const li = document.createElement('li');
+        li.className = `priority-${n.priority}`;
+        const ts = document.createElement('span');
+        ts.className = 'timestamp';
+        ts.textContent = new Date(n.timestamp).toLocaleString();
+        const msg = document.createElement('span');
+        msg.className = 'msg';
+        msg.textContent = n.message;
+        li.appendChild(ts);
+        li.appendChild(msg);
+        list.appendChild(li);
+      });
+    } catch (err) {
+      console.error('[NotificationHub] load error', err);
+    }
+  }
+
+  logo.addEventListener('click', async (e) => {
+    e.preventDefault();
+    hub.classList.toggle('open');
+    hub.hidden = !hub.classList.contains('open');
+    if (hub.classList.contains('open')) {
+      await loadNotifications();
+    }
+  });
+
+  document.addEventListener('click', (e) => {
+    if (!hub.contains(e.target) && !logo.contains(e.target)) {
+      hub.classList.remove('open');
+      hub.hidden = true;
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initNotificationHub);

--- a/BlogposterCMS/public/assets/plainspace/admin/partials/top-header.html
+++ b/BlogposterCMS/public/assets/plainspace/admin/partials/top-header.html
@@ -17,3 +17,6 @@
       <img id="logout-icon" src="/assets/icons/log-out.svg" class="icon" />
     </div>
   </div>
+<div id="notification-hub" class="notification-hub" hidden>
+  <ul></ul>
+</div>

--- a/BlogposterCMS/public/assets/scss/components/_notification-hub.scss
+++ b/BlogposterCMS/public/assets/scss/components/_notification-hub.scss
@@ -1,0 +1,54 @@
+/* =============================================================================
+   components/_notification-hub.scss — Slide-down notification list
+   =============================================================================
+ */
+
+.notification-hub {
+  position: absolute;
+  top: 56px; // below top-header
+  right: 16px;
+  width: 300px;
+  max-height: 50vh;
+  overflow-y: auto;
+  background: var(--color-white);
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 99;
+
+  &.open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    li {
+      display: flex;
+      gap: 8px;
+      padding: 8px;
+      border-bottom: 1px solid #eee;
+      font-size: 0.875rem;
+
+      &.priority-critical { background: #fddede; }
+      &.priority-warning { background: #fff4ce; }
+      &.priority-info { background: #f0f0f0; }
+    }
+
+    .timestamp {
+      color: #666;
+      flex-shrink: 0;
+    }
+    .msg {
+      flex-grow: 1;
+    }
+  }
+}

--- a/BlogposterCMS/public/assets/scss/site.scss
+++ b/BlogposterCMS/public/assets/scss/site.scss
@@ -11,6 +11,7 @@
 @import 'components/sidebar-bubble';
 @import 'components/header-main';
 @import 'components/top-header';
+@import 'components/notification-hub';
 @import 'components/content-header';
 @import 'pages/pages';
 @import 'pages/media';

--- a/BlogposterCMS/tests/notificationManager.test.js
+++ b/BlogposterCMS/tests/notificationManager.test.js
@@ -31,7 +31,8 @@ async function testFileLogIntegration() {
   const beforeSize = fs.existsSync(logPath) ? fs.statSync(logPath).size : 0;
 
   const nm = loadNotificationManager();
-  await nm.initialize({ motherEmitter: {}, app: {}, isCore: true, jwt: 't' });
+  const stubEmitter = { on() {}, emit() {} };
+  await nm.initialize({ motherEmitter: stubEmitter, app: {}, isCore: true, jwt: 't' });
   nm._emitter.notify({ moduleName: 'test', notificationType: 'system', priority: 'info', message: 'Hello Test', timestamp: new Date().toISOString() });
 
   await new Promise(r => setTimeout(r, 100));
@@ -42,5 +43,14 @@ async function testFileLogIntegration() {
 
 test('notification manager writes to log file', async () => {
   await testFileLogIntegration();
+});
+
+test('getRecentNotifications returns array', async () => {
+  const nm = loadNotificationManager();
+  const stubEmitter = { on() {}, emit() {} };
+  await nm.initialize({ motherEmitter: stubEmitter, app: {}, isCore: true, jwt: 't' });
+  const { getRecentNotifications } = require('../mother/modules/notificationManager/notificationManagerService');
+  const list = getRecentNotifications(1);
+  assert(Array.isArray(list), 'should return array');
 });
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Added notification hub UI and meltdown event `getRecentNotifications`.
 - Layout template previews now stored via `preview_path`; widget shows preview images.
 - Layout templates widget now includes a create button and rearranged filters below it.
 - Increased text block auto-save delay to 1.5s and skip identical saves to reduce API load.

--- a/docs/modules/notificationManager.md
+++ b/docs/modules/notificationManager.md
@@ -10,7 +10,7 @@ Dispatches system notifications to configured integrations such as email or web 
 - Listens to the internal `notificationEmitter` and forwards messages to active integrations.
 
 ## Listened Events
-- This module does not expose meltdown events directly. Instead it listens on `notificationEmitter` for `notify` events.
+- The manager primarily listens on `notificationEmitter` for `notify` events. It also exposes a meltdown event `getRecentNotifications` to fetch log entries for the admin UI.
 
 Each integration can perform its own security checks before sending data externally.
 


### PR DESCRIPTION
## Summary
- add notification hub styles and script
- expose `getRecentNotifications` meltdown event
- document new event and changelog entry
- extend tests for notification manager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68493f3ecb848328b6991136e02ee366