### PR TITLE
Add system modules tab and metadata

### DIFF
--- a/BlogposterCMS/mother/modules/auth/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/auth/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "auth",
+  "version": "0.3.2",
+  "description": "Core authentication services."
+}

--- a/BlogposterCMS/mother/modules/databaseManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/databaseManager/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "databaseManager",
+  "version": "0.3.2",
+  "description": "Gateway between modules and the database."
+}

--- a/BlogposterCMS/mother/modules/dependencyLoader/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/dependencyLoader/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "dependencyLoader",
+  "version": "0.3.2",
+  "description": "Whitelist manager for community module dependencies."
+}

--- a/BlogposterCMS/mother/modules/importer/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/importer/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "importer",
+  "version": "0.3.2",
+  "description": "Handles content importers from other platforms."
+}

--- a/BlogposterCMS/mother/modules/mediaManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/mediaManager/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "mediaManager",
+  "version": "0.3.2",
+  "description": "Manages media library files and folders."
+}

--- a/BlogposterCMS/mother/modules/moduleLoader/index.js
+++ b/BlogposterCMS/mother/modules/moduleLoader/index.js
@@ -25,6 +25,7 @@ const {
   ensureModuleRegistrySchema,
   initGetModuleRegistryEvent,
   initListActiveGrapesModulesEvent,
+  initListSystemModulesEvent,
   getModuleRegistry,
   insertModuleRegistryEntry,
   updateModuleLastError,
@@ -61,6 +62,7 @@ async function loadAllModules({ emitter, app, jwt }) {
   // 2) meltdown Events für Registry-Fetch + Admin-Kram
   initGetModuleRegistryEvent(motherEmitter);
   initListActiveGrapesModulesEvent(motherEmitter);
+  initListSystemModulesEvent(motherEmitter);
   initModuleRegistryAdminEvents(motherEmitter, app);
 
   // Ohne meltdown JWT können wir nichts laden. Also frühzeitiger Abbruch.

--- a/BlogposterCMS/mother/modules/moduleLoader/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/moduleLoader/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "moduleLoader",
+  "version": "0.3.2",
+  "description": "Loads optional modules with sandboxing."
+}

--- a/BlogposterCMS/mother/modules/notificationManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/notificationManager/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "notificationManager",
+  "version": "0.3.2",
+  "description": "Sends notifications to integrations."
+}

--- a/BlogposterCMS/mother/modules/pagesManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/pagesManager/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "pagesManager",
+  "version": "0.3.2",
+  "description": "Manages pages and default content."
+}

--- a/BlogposterCMS/mother/modules/plainSpace/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/plainSpace/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "plainSpace",
+  "version": "0.3.2",
+  "description": "Seeds admin pages and widgets for builder."
+}

--- a/BlogposterCMS/mother/modules/serverManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/serverManager/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "serverManager",
+  "version": "0.3.2",
+  "description": "Stores server location info."
+}

--- a/BlogposterCMS/mother/modules/settingsManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/settingsManager/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "settingsManager",
+  "version": "0.3.2",
+  "description": "Centralized CMS settings service."
+}

--- a/BlogposterCMS/mother/modules/shareManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/shareManager/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "shareManager",
+  "version": "0.3.2",
+  "description": "Creates secure share links for files."
+}

--- a/BlogposterCMS/mother/modules/themeManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/themeManager/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "themeManager",
+  "version": "0.3.2",
+  "description": "Provides installed theme metadata."
+}

--- a/BlogposterCMS/mother/modules/translationManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/translationManager/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "translationManager",
+  "version": "0.3.2",
+  "description": "Stores translations for content strings."
+}

--- a/BlogposterCMS/mother/modules/unifiedSettings/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/unifiedSettings/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "unifiedSettings",
+  "version": "0.3.2",
+  "description": "Registry of settings categories."
+}

--- a/BlogposterCMS/mother/modules/userManagement/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/userManagement/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "userManagement",
+  "version": "0.3.2",
+  "description": "CRUD for users and roles."
+}

--- a/BlogposterCMS/mother/modules/widgetManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/widgetManager/moduleInfo.json
@@ -1,0 +1,5 @@
+{
+  "moduleName": "widgetManager",
+  "version": "0.3.2",
+  "description": "Stores widgets for site and admin."
+}

--- a/BlogposterCMS/public/assets/plainspace/admin/modulesListWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/modulesListWidget.js
@@ -3,12 +3,21 @@ export async function render(el) {
   const meltdownEmit = window.meltdownEmit;
 
   try {
-    const res = await meltdownEmit('getModuleRegistry', {
-      jwt,
-      moduleName: 'moduleLoader',
-      moduleType: 'core'
-    });
-    const modules = Array.isArray(res) ? res : (res?.data ?? []);
+    const [installedRes, systemRes] = await Promise.all([
+      meltdownEmit('getModuleRegistry', {
+        jwt,
+        moduleName: 'moduleLoader',
+        moduleType: 'core'
+      }),
+      meltdownEmit('listSystemModules', {
+        jwt,
+        moduleName: 'moduleLoader',
+        moduleType: 'core'
+      })
+    ]);
+
+    const installed = Array.isArray(installedRes) ? installedRes : (installedRes?.data ?? []);
+    const system = Array.isArray(systemRes) ? systemRes : (systemRes?.data ?? []);
 
     const card = document.createElement('div');
     card.className = 'modules-list-card page-list-card';
@@ -21,28 +30,77 @@ export async function render(el) {
     title.textContent = 'Modules';
 
     titleBar.appendChild(title);
+
+    const tabs = document.createElement('div');
+    tabs.className = 'modules-tabs';
+
+    const installedBtn = document.createElement('button');
+    installedBtn.className = 'modules-tab active';
+    installedBtn.textContent = 'Installed';
+
+    const systemBtn = document.createElement('button');
+    systemBtn.className = 'modules-tab';
+    systemBtn.textContent = 'System';
+
+    tabs.appendChild(installedBtn);
+    tabs.appendChild(systemBtn);
+    titleBar.appendChild(tabs);
     card.appendChild(titleBar);
 
-    const list = document.createElement('ul');
-    list.className = 'modules-list page-list';
+    const installedList = document.createElement('ul');
+    installedList.className = 'modules-list page-list';
 
-    if (!modules.length) {
+    if (!installed.length) {
       const empty = document.createElement('div');
       empty.className = 'empty-state';
       empty.textContent = 'No modules found.';
-      list.appendChild(empty);
+      installedList.appendChild(empty);
     } else {
-      modules.forEach(m => {
+      installed.forEach(m => {
         const li = document.createElement('li');
         const info = m.module_info || {};
         const desc = info.description ? ` - ${info.description}` : '';
         const status = m.is_active ? '' : ' (inactive)';
         li.textContent = `${m.module_name}${desc}${status}`;
-        list.appendChild(li);
+        installedList.appendChild(li);
       });
     }
 
-    card.appendChild(list);
+    const systemList = document.createElement('ul');
+    systemList.className = 'modules-list page-list';
+    systemList.style.display = 'none';
+
+    if (!system.length) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'No modules found.';
+      systemList.appendChild(empty);
+    } else {
+      system.forEach(m => {
+        const li = document.createElement('li');
+        const info = m.moduleInfo || {};
+        const desc = info.description ? ` - ${info.description}` : '';
+        li.textContent = `${m.module_name}${desc}`;
+        systemList.appendChild(li);
+      });
+    }
+
+    card.appendChild(installedList);
+    card.appendChild(systemList);
+
+    installedBtn.addEventListener('click', () => {
+      installedBtn.classList.add('active');
+      systemBtn.classList.remove('active');
+      installedList.style.display = '';
+      systemList.style.display = 'none';
+    });
+
+    systemBtn.addEventListener('click', () => {
+      systemBtn.classList.add('active');
+      installedBtn.classList.remove('active');
+      installedList.style.display = 'none';
+      systemList.style.display = '';
+    });
 
     el.innerHTML = '';
     el.appendChild(card);

--- a/BlogposterCMS/public/assets/scss/pages/_modules.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_modules.scss
@@ -23,3 +23,21 @@
 .modules-list li {
   @extend %page-list-item;
 }
+
+.modules-tabs {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.modules-tab {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+}
+
+.modules-tab.active {
+  border-bottom: 2px solid currentColor;
+  font-weight: bold;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Modules settings widget now separates Installed and System modules.
+- Added `moduleInfo.json` to system modules with version `0.3.2`.
 - Layout template previews now stored via `preview_path`; widget shows preview images.
 - Layout templates widget now includes a create button and rearranged filters below it.
 - Increased text block auto-save delay to 1.5s and skip identical saves to reduce API load.


### PR DESCRIPTION
## Summary
- display Installed and System tabs in modules settings widget
- expose `listSystemModules` event in module loader
- include moduleInfo.json for each system module version `0.3.2`
- style module tabs via SCSS
- document new widget behaviour in changelog

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_68494113d2d483288b53fddd51a9ca6b