### PR TITLE
Fix duplicate SEO editor

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/pageEditorWidgets/pageInfoWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/pageEditorWidgets/pageInfoWidget.js
@@ -5,6 +5,18 @@ const quillUrl = new URL('/assets/js/quillEditor.js', document.baseURI).href;
 
 export async function render(el) {
   const { initQuill } = await import(quillUrl);
+  // Clean up any existing editor instance to avoid duplicates
+  if (window.peDescEditor) {
+    try {
+      const oldRoot = window.peDescEditor.root;
+      if (oldRoot && oldRoot.parentNode) {
+        oldRoot.parentNode.remove();
+      }
+    } catch (err) {
+      console.warn('[pageInfoWidget] failed to remove previous editor', err);
+    }
+    window.peDescEditor = null;
+  }
   const pageData = await window.pageDataLoader.load('getPageById', {
     moduleName: 'pagesManager',
     moduleType: 'core',

--- a/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
@@ -22,6 +22,17 @@ function sanitizeHtml(html) {
 }
 
 export async function render(el, ctx = {}) {
+  if (el.__tbQuill) {
+    try {
+      const oldRoot = el.__tbQuill.root;
+      if (oldRoot && oldRoot.parentNode) {
+        oldRoot.parentNode.remove();
+      }
+    } catch (err) {
+      console.warn('[textBlockWidget] failed to remove previous editor', err);
+    }
+    el.__tbQuill = null;
+  }
   let initQuill = null;
   let quillInstance = null;
   let saveTimer = null;
@@ -32,6 +43,7 @@ export async function render(el, ctx = {}) {
     const html = sanitizeHtml(quillInstance.root.innerHTML.trim());
     quillInstance.off('text-change', textChangeHandler);
     quillInstance = null;
+    el.__tbQuill = null;
     container.innerHTML = html;
     document.removeEventListener('mousedown', outsideHandler, true);
   }
@@ -102,6 +114,7 @@ export async function render(el, ctx = {}) {
     if (!quillInstance) {
       return;
     }
+    el.__tbQuill = quillInstance;
 
     textChangeHandler = () => {
       clearTimeout(saveTimer);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed text block editor in builder to remove old Quill instances on re-render,
+  preventing duplicate toolbars.
+- Fixed SEO description editor in builder to remove old Quill instances before
+  creating a new one, preventing duplicate toolbars.
 - Modules settings widget now separates Installed and System modules.
 - Added `moduleInfo.json` to system modules with version `0.3.2`.
 - Database initialization now adds missing `preview_path` column for layout templates.


### PR DESCRIPTION
## Summary
- clean up old Quill instance before creating SEO description editor
- remove Quill instance for text blocks when rerendering in builder
- document these fixes in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68494866778c8328b1defa41b8461287