### PR TITLE
Fix notification hub initialization

### DIFF
--- a/BlogposterCMS/public/assets/js/notificationHub.js
+++ b/BlogposterCMS/public/assets/js/notificationHub.js
@@ -52,3 +52,4 @@ export default function initNotificationHub() {
 }
 
 document.addEventListener('DOMContentLoaded', initNotificationHub);
+document.addEventListener('top-header-loaded', initNotificationHub);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed notification hub not opening when clicking the logo by initializing after the header loads.
 - Layout templates widget header reorganized: add button moved next to title and filter tabs aligned left.
 - Modules settings widget now separates Installed and System modules.
 - Added `moduleInfo.json` to system modules with version `0.3.2`.


### PR DESCRIPTION
## Summary
- ensure notification hub initializes when the top header loads
- note fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68494b79e80c8328b9127d4e958527c9