### PR TITLE
Add builder global widget feature

### DIFF
--- a/BlogposterCMS/package-lock.json
+++ b/BlogposterCMS/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "blogposter_cms",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "blogposter_cms",
-            "version": "0.4.2",
+            "version": "0.4.3",
             "dependencies": {
                 "@rc-component/color-picker": "^2.0.1",
                 "axios": "^1.7.7",

--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blogposter_cms",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "main": "app.js",
     "scripts": {
         "start": "node app.js",

--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -366,6 +366,7 @@ function ensureLayout(layout = {}, lane = 'public') {
         wrapper.setAttribute('gs-min-h', 4);
         wrapper.dataset.widgetId = def.id;
         wrapper.dataset.instanceId = item.id;
+        if (item.global) wrapper.dataset.global = 'true';
 
         const content = document.createElement('div');
         content.className = 'grid-stack-item-content';
@@ -418,6 +419,7 @@ function ensureLayout(layout = {}, lane = 'public') {
       wrapper.setAttribute('gs-min-h', DEFAULT_ADMIN_ROWS);
       wrapper.dataset.widgetId = def.id;
       wrapper.dataset.instanceId = meta.id || `w${Math.random().toString(36).slice(2,8)}`;
+      if (meta.global) wrapper.dataset.global = 'true';
 
       const content = document.createElement('div');
       content.className = 'grid-stack-item-content';
@@ -434,6 +436,7 @@ function ensureLayout(layout = {}, lane = 'public') {
       const newLayout = items.map(i => ({
         id: i.el.dataset.instanceId,
         widgetId: i.el.dataset.widgetId,
+        global: i.el.dataset.global === 'true',
         x: i.x, y: i.y, w: i.w, h: i.h,
         code: layout.find(l => l.id === i.el.dataset.instanceId)?.code || null
       }));

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -372,6 +372,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     return items.map(el => ({
       id: el.dataset.instanceId,
       widgetId: el.dataset.widgetId,
+      global: el.dataset.global === 'true',
       x: +el.getAttribute('gs-x'),
       y: +el.getAttribute('gs-y'),
       w: +el.getAttribute('gs-w'),
@@ -472,6 +473,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
         hideMenu();
         return;
       }
+      updateGlobalBtn();
       menu.style.display = 'block';
       menu.style.visibility = 'hidden';
       const rect = menuBtn.getBoundingClientRect();
@@ -492,6 +494,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     menu.querySelector('.menu-copy').onclick = () => {
       const clone = el.cloneNode(true);
       clone.dataset.instanceId = genId();
+      clone.dataset.global = el.dataset.global || 'false';
       gridEl.appendChild(clone);
       grid.makeWidget(clone);
       attachRemoveButton(clone);
@@ -514,9 +517,23 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       grid.update(el, { x: Math.round(+el.getAttribute('gs-x')), y: Math.round(+el.getAttribute('gs-y')) });
       menu.style.display = 'none';
     };
-    menu.querySelector('.menu-global').onclick = () => {
-      alert('Global Widget feature not implemented');
+    const globalBtn = menu.querySelector('.menu-global');
+    function updateGlobalBtn() {
+      const isGlobal = el.dataset.global === 'true';
+      globalBtn.innerHTML = `<img src="/assets/icons/globe.svg" class="icon" alt="global" /> ${isGlobal ? 'Unset Global' : 'Set as Global Widget'}`;
+    }
+    globalBtn.onclick = () => {
+      const isGlobal = el.dataset.global === 'true';
+      if (isGlobal) {
+        el.dataset.global = 'false';
+        el.dataset.instanceId = genId();
+      } else {
+        el.dataset.global = 'true';
+        el.dataset.instanceId = `global-${widgetDef.id}`;
+      }
+      updateGlobalBtn();
       menu.style.display = 'none';
+      if (pageId) saveCurrentLayout();
     };
 
     el.appendChild(menuBtn);
@@ -547,11 +564,13 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     if (!widgetDef) return;
     const instId = item.id || genId();
     item.id = instId;
+    const isGlobal = item.global === true;
     if (item.code) codeMap[instId] = item.code;
     const wrapper = document.createElement('div');
     wrapper.classList.add('grid-stack-item');
     wrapper.dataset.widgetId = widgetDef.id;
     wrapper.dataset.instanceId = instId;
+    wrapper.dataset.global = isGlobal ? 'true' : 'false';
     wrapper.setAttribute('gs-x', item.x ?? 0);
     wrapper.setAttribute('gs-y', item.y ?? 0);
     // Larger defaults for builder widgets
@@ -594,6 +613,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     wrapper.classList.add('grid-stack-item');
     wrapper.dataset.widgetId = widgetDef.id;
     wrapper.dataset.instanceId = instId;
+    wrapper.dataset.global = 'false';
     wrapper.setAttribute('gs-x', x);
     wrapper.setAttribute('gs-y', y);
     wrapper.setAttribute('gs-w', w);

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -264,3 +264,15 @@ body.builder-mode #main-header {
   z-index: 100;
 }
 
+.grid-stack-item[data-global="true"]::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 20px;
+  height: 20px;
+  background: url('/assets/icons/globe.svg') no-repeat center/contain;
+  pointer-events: none;
+  z-index: 100;
+}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widgets can now be marked as global in the builder. Editing a global widget updates all pages that use it.
 - Fixed notification hub not opening when clicking the logo by initializing after the header loads.
 - Fixed text block editor in builder to remove old Quill instances on re-render,
   preventing duplicate toolbars.

--- a/docs/modules/plainSpace.md
+++ b/docs/modules/plainSpace.md
@@ -10,6 +10,9 @@ Seeds default admin pages and widgets and handles multi-viewport layouts used by
 - Seeds the admin dashboard pages on first run.
 - Provides `widget.registry.request.v1` for the page builder.
 
+- Widgets can be marked as **global** in the builder. A global widget shares its
+  `instanceId` across pages so editing it updates every occurrence.
+
 ## Listened Events
 - `widget.registry.request.v1`
 


### PR DESCRIPTION
## Summary
- allow widgets to be marked as global and share an instanceId
- show a globe overlay for global widgets
- document global widgets and bump version to 0.4.3

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684952b336e483289d49e3ba9d0aa917