### PR TITLE
Fix builder text block cleanup

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
@@ -42,10 +42,16 @@ export async function render(el, ctx = {}) {
     if (!quillInstance) return;
     const html = sanitizeHtml(quillInstance.root.innerHTML.trim());
     quillInstance.off('text-change', textChangeHandler);
+    // Remove tooltip elements Quill may have added to the document body
+    if (quillInstance.theme && quillInstance.theme.tooltip) {
+      const tip = quillInstance.theme.tooltip.root;
+      if (tip && tip.parentNode) tip.parentNode.removeChild(tip);
+    }
     quillInstance = null;
     el.__tbQuill = null;
     container.innerHTML = html;
     document.removeEventListener('mousedown', outsideHandler, true);
+    document.removeEventListener('pointerdown', outsideHandler, true);
   }
 
   function outsideHandler(ev) {
@@ -136,6 +142,9 @@ export async function render(el, ctx = {}) {
       }, 1500);
     };
     quillInstance.on('text-change', textChangeHandler);
+    // Use pointerdown so clicks on certain elements cannot prevent the
+    // outside handler from firing via stopPropagation on mousedown.
+    document.addEventListener('pointerdown', outsideHandler, true);
     document.addEventListener('mousedown', outsideHandler, true);
     quillInstance.focus();
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed text block editor in builder to clean up tooltip overlays on close,
+  preventing multiple toolbars from stacking.
+- Fixed text block editor in builder so it closes when clicking outside by
+  listening for pointerdown events.
 - Fixed notification hub not opening when clicking the logo by initializing after the header loads.
 - Fixed text block editor in builder to remove old Quill instances on re-render,
   preventing duplicate toolbars.


### PR DESCRIPTION
## Summary
- clean up Quill tooltip overlay when closing text block editor so multiple toolbars don't stack
- update changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68495101f1008328bdb7ec20c7f06531