### PR TITLE
Fix builder image selection

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -204,6 +204,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
             <label>JS</label>
             <textarea class="editor-js"></textarea>
             <div class="editor-actions">
+              <button class="media-btn">Insert Image</button>
               <button class="save-btn">Save</button>
               <button class="reset-btn">Reset to Default</button>
               <button class="cancel-btn">Cancel</button>
@@ -214,6 +215,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
         htmlEl = overlay.querySelector('.editor-html');
         cssEl = overlay.querySelector('.editor-css');
         jsEl = overlay.querySelector('.editor-js');
+        const mediaBtn = overlay.querySelector('.media-btn');
         const updateRender = () => {
           const finalCss = wrapCss(cssEl.value, overlay.currentSelector);
           renderWidget(el, widgetDef, {
@@ -227,12 +229,32 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
         cssEl.addEventListener('input', updateRender);
         jsEl.addEventListener('input', updateRender);
 
+        mediaBtn.addEventListener('click', async () => {
+          try {
+            const { shareURL } = await window.meltdownEmit('openMediaExplorer', { jwt: window.ADMIN_TOKEN });
+            if (shareURL) {
+              const ta = htmlEl;
+              const start = ta.selectionStart || 0;
+              const end = ta.selectionEnd || 0;
+              const safeUrl = shareURL.replace(/"/g, '&quot;');
+              const imgTag = `<img src="${safeUrl}" alt="" />`;
+              ta.value = ta.value.slice(0, start) + imgTag + ta.value.slice(end);
+              ta.focus();
+              ta.setSelectionRange(start + imgTag.length, start + imgTag.length);
+              updateRender();
+            }
+          } catch (err) {
+            console.error('[Builder] openMediaExplorer error', err);
+          }
+        });
+
         overlay.updateRender = updateRender;
         el.__codeEditor = overlay;
       } else {
         htmlEl = overlay.querySelector('.editor-html');
         cssEl = overlay.querySelector('.editor-css');
         jsEl = overlay.querySelector('.editor-js');
+        const mediaBtn = overlay.querySelector('.media-btn');
         overlay.updateRender = () => {
           const finalCss = wrapCss(cssEl.value, overlay.currentSelector);
           renderWidget(el, widgetDef, {
@@ -240,6 +262,24 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
             css: finalCss,
             js: jsEl.value
           });
+        };
+        mediaBtn.onclick = async () => {
+          try {
+            const { shareURL } = await window.meltdownEmit('openMediaExplorer', { jwt: window.ADMIN_TOKEN });
+            if (shareURL) {
+              const ta = htmlEl;
+              const start = ta.selectionStart || 0;
+              const end = ta.selectionEnd || 0;
+              const safeUrl = shareURL.replace(/"/g, '&quot;');
+              const imgTag = `<img src="${safeUrl}" alt="" />`;
+              ta.value = ta.value.slice(0, start) + imgTag + ta.value.slice(end);
+              ta.focus();
+              ta.setSelectionRange(start + imgTag.length, start + imgTag.length);
+              overlay.updateRender && overlay.updateRender();
+            }
+          } catch (err) {
+            console.error('[Builder] openMediaExplorer error', err);
+          }
         };
       }
       const instId = el.dataset.instanceId;

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -226,6 +226,10 @@
   text-align: right;
 }
 
+.widget-code-editor .media-btn {
+  margin-right: auto;
+}
+
 .grid-stack-item .widget-remove .icon {
   width: 16px;
   height: 16px;

--- a/BlogposterCMS/public/assets/scss/pages/_media.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_media.scss
@@ -1,5 +1,12 @@
 .media-explorer {
   padding: 10px;
+  width: 70vw;
+  max-height: 80vh;
+  overflow: auto;
+}
+
+.media-explorer::backdrop {
+  background: rgba(0, 0, 0, 0.3);
 }
 .media-list {
   list-style: none;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widget code editor now includes an "Insert Image" button that uploads to the media explorer and injects an `<img>` tag.
 - Improved media explorer usability with larger dialog and backdrop overlay.
 - Fixed text block editor in builder to clean up tooltip overlays on close,
   preventing multiple toolbars from stacking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Improved media explorer usability with larger dialog and backdrop overlay.
 - Fixed text block editor in builder to clean up tooltip overlays on close,
   preventing multiple toolbars from stacking.
 - Widgets can now be marked as global in the builder. Editing a global widget updates all pages that use it.


### PR DESCRIPTION
## Summary
- tweak media explorer styles to open larger with a dimmed backdrop
- document the improvement in the changelog

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68495be3e48083289147d845e9fbd41a