### PR TITLE
Add widgets page

### DIFF
--- a/BlogposterCMS/mother/modules/plainSpace/config/adminPages.js
+++ b/BlogposterCMS/mother/modules/plainSpace/config/adminPages.js
@@ -81,7 +81,7 @@ module.exports.ADMIN_PAGES = [
         sidebar: 'default-sidebar',
         inheritsLayout: true
       },
-      widgets: []
+      widgets: ['widgetList']
     }
   },
   {

--- a/BlogposterCMS/mother/modules/plainSpace/config/defaultWidgets.js
+++ b/BlogposterCMS/mother/modules/plainSpace/config/defaultWidgets.js
@@ -129,5 +129,12 @@ module.exports.DEFAULT_WIDGETS = [
     label: 'Themes List',
     content: '/assets/plainspace/admin/themesListWidget.js',
     category: 'core'
+  },
+  {
+    widgetId: 'widgetList',
+    widgetType: ADMIN_LANE,
+    label: 'Widget List',
+    content: '/assets/plainspace/admin/widgetListWidget.js',
+    category: 'core'
   }
 ];

--- a/BlogposterCMS/public/assets/plainspace/admin/widgetListWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/widgetListWidget.js
@@ -1,0 +1,150 @@
+// public/assets/plainspace/admin/widgetListWidget.js
+export async function render(el) {
+  const meltdownEmit = window.meltdownEmit;
+  const jwt = window.ADMIN_TOKEN;
+
+  const ICON_MAP = {
+    counter: 'activity',
+    heroBanner: 'image',
+    textBlock: 'align-left',
+    imageWidget: 'image',
+    headingWidget: 'type',
+    buttonWidget: 'mouse-pointer',
+    systemInfo: 'info',
+    activityLog: 'list',
+    pageInfoEditor: 'file-text',
+    pageSettingsEditor: 'settings',
+    seoImageEditor: 'image',
+    mediaExplorer: 'folder',
+    pageList: 'list',
+    pageStats: 'bar-chart-2',
+    pageInfoWidget: 'file-text',
+    pageSettingsWidget: 'settings',
+    seoImageWidget: 'image',
+    savePageWidget: 'save',
+    contentSummary: 'activity'
+  };
+
+  function getIcon(id, meta) {
+    const name = meta?.icon || ICON_MAP[id] || id;
+    return window.featherIcon ? window.featherIcon(name) :
+      `<img src="/assets/icons/${name}.svg" alt="${name}" />`;
+  }
+
+  let widgets = [];
+  try {
+    const res = await meltdownEmit('widget.registry.request.v1', {
+      lane: 'public',
+      moduleName: 'plainspace',
+      moduleType: 'core',
+      jwt
+    });
+    widgets = Array.isArray(res?.widgets) ? res.widgets : [];
+  } catch (err) {
+    console.error('[widgetList] registry error', err);
+  }
+
+  const globalIds = new Set();
+  try {
+    const res = await meltdownEmit('getPagesByLane', {
+      jwt,
+      moduleName: 'pagesManager',
+      moduleType: 'core',
+      lane: 'public'
+    });
+    const pages = Array.isArray(res?.pages) ? res.pages : res || [];
+    for (const p of pages) {
+      const lay = await meltdownEmit('getLayoutForViewport', {
+        jwt,
+        moduleName: 'plainspace',
+        moduleType: 'core',
+        pageId: p.id,
+        lane: 'public',
+        viewport: 'desktop'
+      });
+      const items = Array.isArray(lay?.layout) ? lay.layout : [];
+      items.forEach(i => { if (i.global) globalIds.add(i.widgetId); });
+    }
+  } catch (err) {
+    console.error('[widgetList] global fetch error', err);
+  }
+
+  function buildList(list, ids) {
+    if (!ids.length) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'No widgets found.';
+      list.appendChild(empty);
+      return;
+    }
+    ids.forEach(id => {
+      const def = widgets.find(w => w.id === id) || { id, metadata:{label:id} };
+      const li = document.createElement('li');
+      li.innerHTML = `${getIcon(def.id, def.metadata)}<span class="widget-name">${def.metadata.label}</span>`;
+      list.appendChild(li);
+    });
+  }
+
+  const card = document.createElement('div');
+  card.className = 'widget-list-card page-list-card';
+
+  const titleBar = document.createElement('div');
+  titleBar.className = 'widget-title-bar page-title-bar';
+  const title = document.createElement('div');
+  title.className = 'widget-title page-title';
+  title.textContent = 'Widgets';
+  const tabs = document.createElement('div');
+  tabs.className = 'widget-tabs';
+  const allBtn = document.createElement('button');
+  allBtn.className = 'widget-tab active';
+  allBtn.textContent = 'All';
+  const globalBtn = document.createElement('button');
+  globalBtn.className = 'widget-tab';
+  globalBtn.textContent = 'Global';
+  tabs.appendChild(allBtn);
+  tabs.appendChild(globalBtn);
+  titleBar.appendChild(title);
+  titleBar.appendChild(tabs);
+  card.appendChild(titleBar);
+
+  const allList = document.createElement('ul');
+  allList.className = 'widget-list page-list';
+  buildList(allList, widgets.map(w => w.id));
+  const globalList = document.createElement('ul');
+  globalList.className = 'widget-list page-list';
+  globalList.style.display = 'none';
+  const globalArray = Array.from(globalIds);
+  if (globalArray.length) {
+    globalArray.forEach(id => {
+      const def = widgets.find(w => w.id === id) || { id, metadata:{label:id} };
+      const li = document.createElement('li');
+      li.classList.add('global-widget');
+      li.innerHTML = `${getIcon(def.id, def.metadata)}<span class="widget-name">${def.metadata.label}</span>`;
+      globalList.appendChild(li);
+    });
+  } else {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'No global widgets.';
+    globalList.appendChild(empty);
+  }
+
+  card.appendChild(allList);
+  card.appendChild(globalList);
+
+  allBtn.addEventListener('click', () => {
+    allBtn.classList.add('active');
+    globalBtn.classList.remove('active');
+    allList.style.display = '';
+    globalList.style.display = 'none';
+  });
+  globalBtn.addEventListener('click', () => {
+    globalBtn.classList.add('active');
+    allBtn.classList.remove('active');
+    allList.style.display = 'none';
+    globalList.style.display = '';
+  });
+
+  el.innerHTML = '';
+  el.appendChild(card);
+}

--- a/BlogposterCMS/public/assets/scss/pages/_widgets.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_widgets.scss
@@ -1,0 +1,52 @@
+.widget-list-card {
+  @extend .page-list-card;
+}
+
+.widget-title-bar {
+  @extend .page-title-bar;
+}
+
+.widget-title {
+  @extend .page-title;
+}
+
+.widget-list {
+  @extend .page-list;
+}
+
+.widget-list .empty-state {
+  @extend %page-list-empty-state;
+}
+
+.widget-list li {
+  @extend %page-list-item;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.widget-name {
+  flex: 1;
+}
+
+.widget-tabs {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.widget-tab {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+}
+
+.widget-tab.active {
+  border-bottom: 2px solid currentColor;
+  font-weight: bold;
+}
+
+.global-widget:hover {
+  box-shadow: 0 0 12px rgba(255, 0, 255, 0.5);
+}

--- a/BlogposterCMS/public/assets/scss/site.scss
+++ b/BlogposterCMS/public/assets/scss/site.scss
@@ -23,3 +23,4 @@
 @import 'components/page-editor';
 @import 'components/text-block-widget';
 @import 'pages/users';
+@import 'pages/widgets';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Added `widgetList` admin widget listing all seeded public widgets with tabs for global widgets. The Widgets admin page is seeded with this widget.
 - Widget code editor now includes an "Insert Image" button that uploads to the media explorer and injects an `<img>` tag.
 - Improved media explorer usability with larger dialog and backdrop overlay.
 - Text block widget now uses a single floating Quill instance instead of creating


### PR DESCRIPTION
## Summary
- list seeded widgets on new widgets.html page
- add admin script to fetch widgets and global widget instances
- style widget list and global widget hover effect
- import widgets page styles
- document widgets page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684970c795ac8328b4e02b4f7bba2830