### PR TITLE
Fix admin search not initializing

### DIFF
--- a/BlogposterCMS/public/assets/js/adminSearch.js
+++ b/BlogposterCMS/public/assets/js/adminSearch.js
@@ -1,66 +1,73 @@
-(document.addEventListener('DOMContentLoaded', () => {
-  const input = document.getElementById('admin-search-input');
-  const results = document.getElementById('admin-search-results');
-  const container = document.querySelector('.search-container');
-  if (!input || !results || !container) return;
+;(function() {
+  function init() {
+    const input = document.getElementById('admin-search-input');
+    const results = document.getElementById('admin-search-results');
+    const container = document.querySelector('.search-container');
+    if (!input || !results || !container) return;
 
-  let timer;
-  let disabled = false;
+    let timer;
+    let disabled = false;
 
-  async function performSearch() {
-    const q = input.value.trim();
-    if (!q) {
-      results.innerHTML = '';
-      results.parentElement.classList.remove('active');
-      return;
-    }
-    try {
-      const res = await window.meltdownEmit('searchPages', {
-        jwt: window.ADMIN_TOKEN,
-        moduleName: 'pagesManager',
-        moduleType: 'core',
-        query: q,
-        lane: 'all',
-        limit: 10
-      });
-      const pages = Array.isArray(res) ? res : (res.pages || res.rows || []);
-      if (pages.length) {
-        results.innerHTML = pages.map(p => `<li data-id="${p.id}" data-slug="${p.slug}" data-lane="${p.lane}">${p.title || p.slug}</li>`).join('');
-      } else {
-        results.innerHTML = '<li class="no-results">No results</li>';
+    async function performSearch() {
+      const q = input.value.trim();
+      if (!q) {
+        results.innerHTML = '';
+        results.parentElement.classList.remove('active');
+        return;
       }
-      results.parentElement.classList.add('active');
-    } catch (err) {
-      if (err && /permission/i.test(err.message)) {
-        input.disabled = true;
-        input.placeholder = 'Search unavailable';
-        disabled = true;
+      try {
+        const res = await window.meltdownEmit('searchPages', {
+          jwt: window.ADMIN_TOKEN,
+          moduleName: 'pagesManager',
+          moduleType: 'core',
+          query: q,
+          lane: 'all',
+          limit: 10
+        });
+        const pages = Array.isArray(res) ? res : (res.pages || res.rows || []);
+        if (pages.length) {
+          results.innerHTML = pages.map(p => `<li data-id="${p.id}" data-slug="${p.slug}" data-lane="${p.lane}">${p.title || p.slug}</li>`).join('');
+        } else {
+          results.innerHTML = '<li class="no-results">No results</li>';
+        }
+        results.parentElement.classList.add('active');
+      } catch (err) {
+        if (err && /permission/i.test(err.message)) {
+          input.disabled = true;
+          input.placeholder = 'Search unavailable';
+          disabled = true;
+        }
+        console.error('searchPages failed', err);
       }
-      console.error('searchPages failed', err);
     }
+
+    input.addEventListener('input', () => {
+      if (disabled) return;
+      clearTimeout(timer);
+      container.classList.add('open');
+      timer = setTimeout(performSearch, 300);
+    });
+
+    results.addEventListener('click', e => {
+      if (e.target.tagName === 'LI') {
+        const id = e.target.dataset.id;
+        window.location.href = `/admin/pages/edit/${id}`;
+        results.parentElement.classList.remove('active');
+        container.classList.remove('open');
+      }
+    });
+
+    document.addEventListener('click', e => {
+      if (!results.contains(e.target) && e.target !== input) {
+        results.parentElement.classList.remove('active');
+        container.classList.remove('open');
+      }
+    });
   }
 
-  input.addEventListener('input', () => {
-    if (disabled) return;
-    clearTimeout(timer);
-    container.classList.add('open');
-    timer = setTimeout(performSearch, 300);
-  });
-
-  results.addEventListener('click', e => {
-    if (e.target.tagName === 'LI') {
-      const id = e.target.dataset.id;
-      window.location.href = `/admin/pages/edit/${id}`;
-      results.parentElement.classList.remove('active');
-      container.classList.remove('open');
-    }
-  });
-
-  document.addEventListener('click', e => {
-    if (!results.contains(e.target) && e.target !== input) {
-      results.parentElement.classList.remove('active');
-      container.classList.remove('open');
-    }
-  });
-}));
-
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed admin search not initializing when scripts load after DOMContentLoaded.
 - Added `widgetList` admin widget listing all seeded public widgets with tabs for global widgets. The Widgets admin page is seeded with this widget.
 - User management widget now includes a Permissions tab for viewing and creating permissions.
 - Widget code editor now includes an "Insert Image" button that uploads to the media explorer and injects an `<img>` tag.


### PR DESCRIPTION
## Summary
- fix admin search initialization so event handlers run when loaded
- update changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849750971e883288864af7fddf75cc1