### PR TITLE
Add Permissions page and default permissions

### DIFF
--- a/BlogposterCMS/mother/modules/plainSpace/config/adminPages.js
+++ b/BlogposterCMS/mother/modules/plainSpace/config/adminPages.js
@@ -184,6 +184,20 @@ module.exports.ADMIN_PAGES = [
     }
   },
   {
+    title: 'Permissions',
+    slug: 'permissions',
+    parentSlug: 'settings',
+    lane: 'admin',
+    config: {
+      layout: {
+        header: 'top-header',
+        sidebar: 'settings-sidebar',
+        inheritsLayout: true
+      },
+      widgets: ['permissionsList']
+    }
+  },
+  {
     title: 'Modules',
     slug: 'modules',
     parentSlug: 'settings',

--- a/BlogposterCMS/mother/modules/plainSpace/config/defaultWidgets.js
+++ b/BlogposterCMS/mother/modules/plainSpace/config/defaultWidgets.js
@@ -117,6 +117,13 @@ module.exports.DEFAULT_WIDGETS = [
     category: 'core'
   },
   {
+    widgetId: 'permissionsList',
+    widgetType: ADMIN_LANE,
+    label: 'Permissions List',
+    content: '/assets/plainspace/admin/permissionsWidget.js',
+    category: 'core'
+  },
+  {
     widgetId: 'layoutTemplates',
     widgetType: ADMIN_LANE,
     label: 'Layouts',

--- a/BlogposterCMS/mother/modules/userManagement/index.js
+++ b/BlogposterCMS/mother/modules/userManagement/index.js
@@ -11,6 +11,7 @@ const {
   ensureUserManagementDatabase,
   ensureUserManagementSchemaAndTables,
   ensureDefaultRoles,
+  ensureDefaultPermissions,
   ensureFirstUserIsAdmin
 } = require('./userInitService');
 
@@ -38,7 +39,9 @@ async function initialize({ motherEmitter, app, dbConfig, isCore, jwt }) {
     await ensureUserManagementSchemaAndTables(motherEmitter, jwt);
     // C) Create default roles (admin, standard) if missing
     await ensureDefaultRoles(motherEmitter, jwt);
-    
+    // D) Ensure default permissions for system to work
+    await ensureDefaultPermissions(motherEmitter, jwt);
+
     await ensureFirstUserIsAdmin(motherEmitter, jwt);
 
     // D) Now set up meltdown event listeners

--- a/BlogposterCMS/public/assets/plainspace/admin/permissionsWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/permissionsWidget.js
@@ -1,0 +1,91 @@
+export async function render(el) {
+  const jwt = window.ADMIN_TOKEN;
+  const meltdownEmit = window.meltdownEmit;
+
+  let permissions = [];
+
+  async function fetchPermissions() {
+    const res = await meltdownEmit('getAllPermissions', {
+      jwt,
+      moduleName: 'userManagement',
+      moduleType: 'core'
+    });
+    permissions = Array.isArray(res) ? res : (res?.data ?? []);
+  }
+
+  function buildCard() {
+    const card = document.createElement('div');
+    card.className = 'permissions-card';
+
+    const titleBar = document.createElement('div');
+    titleBar.className = 'permissions-title-bar';
+
+    const title = document.createElement('div');
+    title.className = 'permissions-title';
+    title.textContent = 'Permissions';
+
+    const addPermBtn = document.createElement('img');
+    addPermBtn.src = '/assets/icons/plus.svg';
+    addPermBtn.alt = 'Add permission';
+    addPermBtn.title = 'Add new permission';
+    addPermBtn.className = 'icon add-permission-btn';
+
+    addPermBtn.addEventListener('click', async () => {
+      const key = prompt('Permission key:');
+      if (!key) return;
+      const desc = prompt('Description (optional):') || '';
+      try {
+        await meltdownEmit('createPermission', {
+          jwt,
+          moduleName: 'userManagement',
+          moduleType: 'core',
+          permissionKey: key,
+          description: desc
+        });
+        await fetchPermissions();
+        renderPermissions();
+      } catch (err) {
+        alert('Error: ' + err.message);
+      }
+    });
+
+    titleBar.appendChild(title);
+    titleBar.appendChild(addPermBtn);
+    card.appendChild(titleBar);
+
+    const permListEl = document.createElement('ul');
+    permListEl.className = 'permissions-list';
+    card.appendChild(permListEl);
+
+    return { card, permListEl };
+  }
+
+  let permList;
+
+  function renderPermissions() {
+    permList.innerHTML = '';
+    if (!permissions.length) {
+      const empty = document.createElement('li');
+      empty.className = 'empty-state';
+      empty.textContent = 'No permissions found.';
+      permList.appendChild(empty);
+    } else {
+      permissions.forEach(p => {
+        const li = document.createElement('li');
+        li.textContent = p.permission_key + (p.description ? ` - ${p.description}` : '');
+        permList.appendChild(li);
+      });
+    }
+  }
+
+  try {
+    await fetchPermissions();
+    const built = buildCard();
+    permList = built.permListEl;
+    renderPermissions();
+    el.innerHTML = '';
+    el.appendChild(built.card);
+  } catch (err) {
+    el.innerHTML = `<div class="error">Failed to load permissions: ${err.message}</div>`;
+  }
+}

--- a/BlogposterCMS/public/assets/scss/pages/_permissions.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_permissions.scss
@@ -1,0 +1,27 @@
+.permissions-card {
+  @extend .page-list-card;
+}
+
+.permissions-title-bar {
+  @extend .page-title-bar;
+}
+
+.permissions-title {
+  @extend .page-title;
+}
+
+.permissions-list {
+  @extend .page-list;
+}
+
+.permissions-list .empty-state {
+  @extend %page-list-empty-state;
+}
+
+.permissions-list li {
+  @extend %page-list-item;
+}
+
+.add-permission-btn {
+  @extend .add-page-btn;
+}

--- a/BlogposterCMS/public/assets/scss/site.scss
+++ b/BlogposterCMS/public/assets/scss/site.scss
@@ -23,4 +23,5 @@
 @import 'components/page-editor';
 @import 'components/text-block-widget';
 @import 'pages/users';
+@import 'pages/permissions';
 @import 'pages/widgets';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Added dedicated Permissions admin page with a new widget for listing and
+  creating permissions. Default permissions are seeded at startup.
 - Added `widgetList` admin widget listing all seeded public widgets with tabs for global widgets. The Widgets admin page is seeded with this widget.
 - User management widget now includes a Permissions tab for viewing and creating permissions.
 - Widget code editor now includes an "Insert Image" button that uploads to the media explorer and injects an `<img>` tag.


### PR DESCRIPTION
## Summary
- seed default permissions at startup
- create permissions admin widget and styles
- seed permissions admin page and widget
- update SCSS imports
- document in changelog

## Testing
- `npx jest --runInBand` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849759e24a88328a294024af1f1561d