### PR TITLE
Fix widget list API load

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/widgetListWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/widgetListWidget.js
@@ -53,17 +53,21 @@ export async function render(el) {
       lane: 'public'
     });
     const pages = Array.isArray(res?.pages) ? res.pages : res || [];
-    for (const p of pages) {
-      const lay = await meltdownEmit('getLayoutForViewport', {
-        jwt,
-        moduleName: 'plainspace',
-        moduleType: 'core',
-        pageId: p.id,
-        lane: 'public',
-        viewport: 'desktop'
-      });
-      const items = Array.isArray(lay?.layout) ? lay.layout : [];
-      items.forEach(i => { if (i.global) globalIds.add(i.widgetId); });
+    if (pages.length > 20) {
+      console.warn('[widgetList] Too many pages, skipping global widget lookup');
+    } else {
+      for (const p of pages) {
+        const lay = await meltdownEmit('getLayoutForViewport', {
+          jwt,
+          moduleName: 'plainspace',
+          moduleType: 'core',
+          pageId: p.id,
+          lane: 'public',
+          viewport: 'desktop'
+        });
+        const items = Array.isArray(lay?.layout) ? lay.layout : [];
+        items.forEach(i => { if (i.global) globalIds.add(i.widgetId); });
+      }
     }
   } catch (err) {
     console.error('[widgetList] global fetch error', err);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Optimized widget list widget to skip global widget checks when many pages exist, preventing API rate limit errors in the admin dashboard.
 - Fixed "Add new permission" button in user settings to open the Permissions page.
 - Added dedicated Permissions admin page with a new widget for listing and
   creating permissions. Default permissions are seeded at startup.


### PR DESCRIPTION
## Summary
- skip widget global check if site has a lot of pages
- document the change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68498574c02c8328add5127eb8d3e684