### PR TITLE
Update page list widget icons

### DIFF
--- a/BlogposterCMS/public/assets/js/icons.js
+++ b/BlogposterCMS/public/assets/js/icons.js
@@ -6,7 +6,9 @@ window.featherIcons = {
   published:   '/assets/icons/check-circle.svg',       
   delete:      '/assets/icons/trash-2.svg',
   editSlug:    '/assets/icons/edit-3.svg',
-  pencil:      '/assets/icons/pencil-gradient.svg'
+  pencil:      '/assets/icons/pencil-gradient.svg',
+  share:       '/assets/icons/share.svg',
+  'external-link': '/assets/icons/external-link.svg'
 };
 
 window.featherIcon = function(name, extraClass = '') {

--- a/BlogposterCMS/public/assets/plainspace/admin/defaultwidgets/pageList.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/defaultwidgets/pageList.js
@@ -151,11 +151,13 @@ function renderPages(pages, list) {
               ${window.featherIcon('edit', 'edit-page" title="Edit page')}
               ${window.featherIcon('pencil', 'edit-layout" title="Edit layout')}
               ${window.featherIcon(page.status === 'draft' ? 'draft' : 'published', 'toggle-draft" title="' + (page.status === 'draft' ? 'Mark as published' : 'Mark as draft') + '"')}
+              ${window.featherIcon('external-link', 'view-page" title="Open page')}
+              ${window.featherIcon('share', 'share-page" title="Share page link')}
               ${window.featherIcon('delete', 'delete-page" title="Delete page')}
           </span>
         </div>
         <div class="page-slug-row">
-          <span class="page-slug" contenteditable="true">${page.slug}</span>
+          <span class="page-slug" contenteditable="true">/${page.slug}</span>
           ${window.featherIcon('editSlug', 'edit-slug" title="Edit slug')}
         </div>
       </div>
@@ -170,10 +172,13 @@ function renderPages(pages, list) {
       }
     });
     slugEl.addEventListener('blur', (e) => {
-      const newSlug = e.target.textContent.trim();
+      const newSlug = e.target.textContent.trim().replace(/^\//, '');
       if (newSlug !== page.slug) {
         updateSlug(page, newSlug);
+        page.slug = newSlug;
       }
+      // always show with leading slash
+      slugEl.textContent = `/${page.slug}`;
     });
 
     // Set as home
@@ -188,6 +193,12 @@ function renderPages(pages, list) {
 
     // Toggle draft
     li.querySelector('.toggle-draft').addEventListener('click', () => toggleDraft(page));
+
+    // View page
+    li.querySelector('.view-page').addEventListener('click', () => viewPage(page));
+
+    // Share page
+    li.querySelector('.share-page').addEventListener('click', () => sharePage(page));
 
     // Delete
     li.querySelector('.delete-page').addEventListener('click', () => deletePage(page.id));
@@ -284,5 +295,19 @@ async function deletePage(id) {
       console.error('deletePage failed', err);
       alert('Failed to delete page: ' + err.message);
     }
+  }
+}
+
+function viewPage(page) {
+  window.open(`/${page.slug}`, '_blank');
+}
+
+async function sharePage(page) {
+  const url = `${window.location.origin}/${page.slug}`;
+  try {
+    await navigator.clipboard.writeText(url);
+    alert('Page link copied to clipboard');
+  } catch (err) {
+    prompt('Copy URL', url);
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Page list widget now prefixes slugs with `/` and includes new icons to view or share pages directly.
 - Optimized widget list widget to skip global widget checks when many pages exist, preventing API rate limit errors in the admin dashboard.
 - Fixed new default widgets not seeding when `PLAINSPACE_SEEDED` was already set,
   ensuring `widgetList` and future widgets appear after upgrades.


### PR DESCRIPTION
## Summary
- show `/` prefix on editable slugs in page list
- add buttons to open and share a page
- expose new icon mappings for sharing and viewing
- document page list UI improvements in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68498a6117588328ac5cee97d0daa6e1