### PR TITLE
Sync Quill HTML with code editor

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -34,6 +34,19 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   }
 
   const codeMap = {};
+  let gridEl;
+  document.addEventListener('textBlockHtmlUpdate', e => {
+    const { instanceId, html } = e.detail || {};
+    if (!instanceId || typeof html !== 'string') return;
+    codeMap[instanceId] = codeMap[instanceId] || {};
+    codeMap[instanceId].html = html;
+
+    const wrapper = gridEl?.querySelector(`.grid-stack-item[data-instance-id="${instanceId}"]`);
+    if (wrapper && wrapper.__codeEditor && wrapper.__codeEditor.style.display !== 'none') {
+      const htmlField = wrapper.__codeEditor.querySelector('.editor-html');
+      if (htmlField) htmlField.value = html;
+    }
+  });
   let activeLockedEl = null;
   const genId = () => `w${Math.random().toString(36).slice(2,8)}`;
 
@@ -195,6 +208,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       if (!overlay) {
         overlay = document.createElement('div');
         overlay.className = 'widget-code-editor';
+        overlay.dataset.instanceId = el.dataset.instanceId;
         overlay.innerHTML = `
           <div class="editor-inner">
             <label>HTML</label>
@@ -251,6 +265,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
         overlay.updateRender = updateRender;
         el.__codeEditor = overlay;
       } else {
+        overlay.dataset.instanceId = el.dataset.instanceId;
         htmlEl = overlay.querySelector('.editor-html');
         cssEl = overlay.querySelector('.editor-css');
         jsEl = overlay.querySelector('.editor-js');
@@ -392,7 +407,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   });
 
   contentEl.innerHTML = `<div id="builderGrid" class="grid-stack builder-grid"></div>`;
-  const gridEl = document.getElementById('builderGrid');
+  gridEl = document.getElementById('builderGrid');
   // Enable floating mode for easier widget placement in the builder
   const grid = GridStack.init({ float: true, cellHeight: 5, columnWidth: 5, column: 64 }, gridEl);
 

--- a/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/textBlockWidget.js
@@ -79,6 +79,11 @@ function disableEdit() {
     if (tip && tip.parentNode) tip.parentNode.removeChild(tip);
   }
   activeContainer.innerHTML = html;
+  if (activeCtx && activeCtx.id) {
+    document.dispatchEvent(new CustomEvent('textBlockHtmlUpdate', {
+      detail: { instanceId: activeCtx.id, html }
+    }));
+  }
   activeContainer = null;
   activeCtx = null;
   globalWrapper.style.display = 'none';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Text block widget editing now syncs Quill output with the code editor HTML
+  field in the builder, allowing manual HTML tweaks.
 - Optimized widget list widget to skip global widget checks when many pages exist, preventing API rate limit errors in the admin dashboard.
 - Fixed new default widgets not seeding when `PLAINSPACE_SEEDED` was already set,
   ensuring `widgetList` and future widgets appear after upgrades.


### PR DESCRIPTION
## Summary
- sync Quill output with builder's code editor
- dispatch custom event when text block editing ends
- update builder renderer to listen for the event and update fields
- document the change

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_68498b08792483288fd097067edf2799