### PR TITLE
Add gradient layout icon to admin navigation

### DIFF
--- a/BlogposterCMS/public/assets/icons/layout-gradient.svg
+++ b/BlogposterCMS/public/assets/icons/layout-gradient.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="url(#grad)" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" class="feather feather-layout">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#008080" />
+      <stop offset="50%" stop-color="#FF00FF" />
+      <stop offset="100%" stop-color="#FFA500" />
+    </linearGradient>
+  </defs>
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+  <line x1="3" y1="9" x2="21" y2="9"></line>
+  <line x1="9" y1="21" x2="9" y2="9"></line>
+</svg>

--- a/BlogposterCMS/public/assets/plainspace/admin/partials/default-sidebar.html
+++ b/BlogposterCMS/public/assets/plainspace/admin/partials/default-sidebar.html
@@ -17,11 +17,11 @@
       <span class="label">Widgets</span>
     </a>
     <a href="/admin/content/layouts" class="sidebar-item">
-      <img src="/assets/icons/layout.svg" class="icon" alt="Layouts"/>
+      <img src="/assets/icons/layout-gradient.svg" class="icon" alt="Layouts"/>
       <span class="label">Layouts</span>
     </a>
     <a href="/admin/content/theme" class="sidebar-item">
-      <img src="/assets/icons/layout.svg" class="icon" alt="Theme"/>
+      <img src="/assets/icons/layout-gradient.svg" class="icon" alt="Theme"/>
       <span class="label">Themes</span>
     </a>
   </nav>

--- a/BlogposterCMS/public/assets/plainspace/admin/partials/settings-sidebar.html
+++ b/BlogposterCMS/public/assets/plainspace/admin/partials/settings-sidebar.html
@@ -13,7 +13,7 @@
       <span class="label">Modules</span>
     </a>
     <a href="/admin/settings/themes" class="sidebar-item">
-      <img src="/assets/icons/layout.svg" class="icon" alt="Themes" />
+      <img src="/assets/icons/layout-gradient.svg" class="icon" alt="Themes" />
       <span class="label">Themes</span>
     </a>
   </nav>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Admin navigation now uses a gradient layout icon for improved visual consistency.
 - Text block widget editing now syncs Quill output with the code editor HTML
   field in the builder, allowing manual HTML tweaks.
 - Page list widget now prefixes slugs with `/` and includes new icons to view or share pages directly.


### PR DESCRIPTION
## Summary
- add new gradient `layout` icon
- use gradient layout icon in default and settings sidebars
- document the change in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68498e09bb78832880879092ce77b3d1