### PR TITLE
Add permission group management

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/permissionsWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/permissionsWidget.js
@@ -3,6 +3,7 @@ export async function render(el) {
   const meltdownEmit = window.meltdownEmit;
 
   let permissions = [];
+  let roles = [];
 
   async function fetchPermissions() {
     const res = await meltdownEmit('getAllPermissions', {
@@ -11,6 +12,15 @@ export async function render(el) {
       moduleType: 'core'
     });
     permissions = Array.isArray(res) ? res : (res?.data ?? []);
+  }
+
+  async function fetchRoles() {
+    const res = await meltdownEmit('getAllRoles', {
+      jwt,
+      moduleName: 'userManagement',
+      moduleType: 'core'
+    });
+    roles = Array.isArray(res) ? res : (res?.data ?? []);
   }
 
   function buildCard() {
@@ -29,6 +39,12 @@ export async function render(el) {
     addPermBtn.alt = 'Add permission';
     addPermBtn.title = 'Add new permission';
     addPermBtn.className = 'icon add-permission-btn';
+
+    const addGroupBtn = document.createElement('img');
+    addGroupBtn.src = '/assets/icons/plus.svg';
+    addGroupBtn.alt = 'Add group';
+    addGroupBtn.title = 'Add permission group';
+    addGroupBtn.className = 'icon add-group-btn';
 
     addPermBtn.addEventListener('click', async () => {
       const key = prompt('Permission key:');
@@ -49,18 +65,60 @@ export async function render(el) {
       }
     });
 
+    addGroupBtn.addEventListener('click', async () => {
+      const name = prompt('Group name:');
+      if (!name) return;
+      const permStr = prompt('Permissions JSON:', '{}') || '{}';
+      let perms;
+      try {
+        perms = JSON.parse(permStr);
+      } catch (e) {
+        alert('Invalid JSON');
+        return;
+      }
+      try {
+        await meltdownEmit('createRole', {
+          jwt,
+          moduleName: 'userManagement',
+          moduleType: 'core',
+          roleName: name,
+          permissions: perms
+        });
+        await fetchRoles();
+        renderRoles();
+      } catch (err) {
+        alert('Error: ' + err.message);
+      }
+    });
+
     titleBar.appendChild(title);
+    titleBar.appendChild(addGroupBtn);
     titleBar.appendChild(addPermBtn);
     card.appendChild(titleBar);
+
+    const groupLabel = document.createElement('div');
+    groupLabel.className = 'permissions-sub-title';
+    groupLabel.textContent = 'Permission Groups';
+    card.appendChild(groupLabel);
+
+    const roleListEl = document.createElement('ul');
+    roleListEl.className = 'roles-list';
+    card.appendChild(roleListEl);
+
+    const permLabel = document.createElement('div');
+    permLabel.className = 'permissions-sub-title';
+    permLabel.textContent = 'Single Permissions';
+    card.appendChild(permLabel);
 
     const permListEl = document.createElement('ul');
     permListEl.className = 'permissions-list';
     card.appendChild(permListEl);
 
-    return { card, permListEl };
+    return { card, permListEl, roleListEl };
   }
 
   let permList;
+  let roleList;
 
   function renderPermissions() {
     permList.innerHTML = '';
@@ -78,10 +136,29 @@ export async function render(el) {
     }
   }
 
+  function renderRoles() {
+    roleList.innerHTML = '';
+    if (!roles.length) {
+      const empty = document.createElement('li');
+      empty.className = 'empty-state';
+      empty.textContent = 'No permission groups found.';
+      roleList.appendChild(empty);
+    } else {
+      roles.forEach(r => {
+        const li = document.createElement('li');
+        li.textContent = r.role_name + (r.description ? ` - ${r.description}` : '');
+        roleList.appendChild(li);
+      });
+    }
+  }
+
   try {
     await fetchPermissions();
+    await fetchRoles();
     const built = buildCard();
     permList = built.permListEl;
+    roleList = built.roleListEl;
+    renderRoles();
     renderPermissions();
     el.innerHTML = '';
     el.appendChild(built.card);

--- a/BlogposterCMS/public/assets/scss/pages/_permissions.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_permissions.scss
@@ -14,7 +14,15 @@
   @extend .page-list;
 }
 
+.roles-list {
+  @extend .page-list;
+}
+
 .permissions-list .empty-state {
+  @extend %page-list-empty-state;
+}
+
+.roles-list .empty-state {
   @extend %page-list-empty-state;
 }
 
@@ -22,6 +30,20 @@
   @extend %page-list-item;
 }
 
+.roles-list li {
+  @extend %page-list-item;
+}
+
 .add-permission-btn {
   @extend .add-page-btn;
+}
+
+.add-group-btn {
+  @extend .add-page-btn;
+}
+
+.permissions-sub-title {
+  font-family: var(--font-heading);
+  font-size: 18px;
+  margin-top: 8px;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Permissions widget now lets admins create permission groups using JSON and shows seeded groups like `admin` and `standard`.
 - Text block widget editing now syncs Quill output with the code editor HTML
   field in the builder, allowing manual HTML tweaks.
 - Page list widget now prefixes slugs with `/` and includes new icons to view or share pages directly.


### PR DESCRIPTION
## Summary
- extend permissions widget to manage permission groups (roles)
- show seeded `admin` and `standard` groups
- allow admins to create groups by entering JSON
- style new roles list
- document the feature in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68499092158083288037983de6455c30