### PR TITLE
Implement widget templates

### DIFF
--- a/BlogposterCMS/public/assets/scss/pages/_widgets.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_widgets.scss
@@ -50,3 +50,7 @@
 .global-widget:hover {
   box-shadow: 0 0 12px rgba(255, 0, 255, 0.5);
 }
+
+.template-widget:hover {
+  box-shadow: 0 0 12px rgba(0, 128, 255, 0.4);
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widget list now includes a Templates tab populated from saved widget templates. Builders can save the current widget state as a template and overwrite after confirmation.
 - Permissions widget now lets admins create permission groups using JSON and shows seeded groups like `admin` and `standard`.
 - Admin navigation now uses a gradient layout icon for improved visual consistency.
 - Text block widget editing now syncs Quill output with the code editor HTML


### PR DESCRIPTION
## Summary
- add 'Templates' tab and dynamic list in widget list
- implement saving current widget as template in builder
- style template list
- document widget templates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684994b57fa08328a7209aa192d9d81d