### PR TITLE
Enable permission group editing

### DIFF
--- a/BlogposterCMS/public/assets/scss/pages/_permissions.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_permissions.scss
@@ -34,6 +34,14 @@
   @extend %page-list-item;
 }
 
+.roles-list .page-name-row {
+  @extend .page-name-row;
+}
+
+.roles-list .page-actions {
+  @extend .page-actions;
+}
+
 .add-permission-btn {
   @extend .add-page-btn;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ El Psy Kongroo
 
 ## [Unreleased]
 - Permissions widget now lets admins create permission groups using JSON and shows seeded groups like `admin` and `standard`.
+- Permission groups can now be edited or removed in the settings UI (system groups remain locked).
 - Admin navigation now uses a gradient layout icon for improved visual consistency.
 - Text block widget editing now syncs Quill output with the code editor HTML
   field in the builder, allowing manual HTML tweaks.


### PR DESCRIPTION
## Summary
- add edit/delete logic for permission groups in the permissions widget
- reuse page-list styles for role actions
- document the new behaviour in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849965cbbe4832882bb735d4ccece03