### PR TITLE
Fix admin search login handling

### DIFF
--- a/BlogposterCMS/public/assets/js/adminSearch.js
+++ b/BlogposterCMS/public/assets/js/adminSearch.js
@@ -5,6 +5,13 @@
     const container = document.querySelector('.search-container');
     if (!input || !results || !container) return;
 
+    // Disable search when no admin token is available
+    if (!window.ADMIN_TOKEN) {
+      input.disabled = true;
+      input.placeholder = 'Login required';
+      return;
+    }
+
     let timer;
     let disabled = false;
 
@@ -35,6 +42,10 @@
         if (err && /permission/i.test(err.message)) {
           input.disabled = true;
           input.placeholder = 'Search unavailable';
+          disabled = true;
+        } else if (err && /(token|auth)/i.test(err.message)) {
+          input.disabled = true;
+          input.placeholder = 'Login required';
           disabled = true;
         }
         console.error('searchPages failed', err);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Disabled admin search when not authenticated and show "Login required" placeholder. Token errors now disable the input instead of failing silently.
 - Widget list now includes a Templates tab populated from saved widget templates. Builders can save the current widget state as a template and overwrite after confirmation.
 - Permissions widget now lets admins create permission groups using JSON and shows seeded groups like `admin` and `standard`.
 - Admin navigation now uses a gradient layout icon for improved visual consistency.


### PR DESCRIPTION
## Summary
- disable admin search when user is not logged in
- show login required hint on token errors
- update changelog

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_6849972fec348328950036292ee79bc1