### PR TITLE
Update moduleInfo versions to 0.5.0

### DIFF
--- a/BlogposterCMS/mother/modules/auth/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/auth/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "auth",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Core authentication services."
 }

--- a/BlogposterCMS/mother/modules/databaseManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/databaseManager/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "databaseManager",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Gateway between modules and the database."
 }

--- a/BlogposterCMS/mother/modules/dependencyLoader/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/dependencyLoader/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "dependencyLoader",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Whitelist manager for community module dependencies."
 }

--- a/BlogposterCMS/mother/modules/importer/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/importer/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "importer",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Handles content importers from other platforms."
 }

--- a/BlogposterCMS/mother/modules/mediaManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/mediaManager/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "mediaManager",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Manages media library files and folders."
 }

--- a/BlogposterCMS/mother/modules/moduleLoader/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/moduleLoader/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "moduleLoader",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Loads optional modules with sandboxing."
 }

--- a/BlogposterCMS/mother/modules/notificationManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/notificationManager/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "notificationManager",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Sends notifications to integrations."
 }

--- a/BlogposterCMS/mother/modules/pagesManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/pagesManager/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "pagesManager",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Manages pages and default content."
 }

--- a/BlogposterCMS/mother/modules/plainSpace/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/plainSpace/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "plainSpace",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Seeds admin pages and widgets for builder."
 }

--- a/BlogposterCMS/mother/modules/serverManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/serverManager/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "serverManager",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Stores server location info."
 }

--- a/BlogposterCMS/mother/modules/settingsManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/settingsManager/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "settingsManager",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Centralized CMS settings service."
 }

--- a/BlogposterCMS/mother/modules/shareManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/shareManager/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "shareManager",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Creates secure share links for files."
 }

--- a/BlogposterCMS/mother/modules/themeManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/themeManager/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "themeManager",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Provides installed theme metadata."
 }

--- a/BlogposterCMS/mother/modules/translationManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/translationManager/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "translationManager",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Stores translations for content strings."
 }

--- a/BlogposterCMS/mother/modules/unifiedSettings/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/unifiedSettings/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "unifiedSettings",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Registry of settings categories."
 }

--- a/BlogposterCMS/mother/modules/userManagement/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/userManagement/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "userManagement",
-  "version": "0.3.3",
+  "version": "0.5.0",
   "description": "CRUD for users and roles."
 }

--- a/BlogposterCMS/mother/modules/widgetManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/widgetManager/moduleInfo.json
@@ -1,5 +1,5 @@
 {
   "moduleName": "widgetManager",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Stores widgets for site and admin."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ El Psy Kongroo
 
 ## [Unreleased]
 - Media explorer no longer throws an error when closed; it now resolves with a `cancelled` flag. Builder and image widget updated.
+- Updated all system module versions to `0.5.0`.
 - Suppressed console errors when closing the media explorer without selecting an image.
 - Snap to Grid option now snaps widget width and height so items align correctly.
 - Set body element to use `var(--font-body)` for consistent typography across the dashboard.


### PR DESCRIPTION
## Summary
- bump moduleInfo versions in core modules to 0.5.0
- note the change in the changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849a49bdbb08328b732a949a2241828