### PR TITLE
Fix builder theme injection

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -1,6 +1,14 @@
 // public/assets/plainspace/admin/builderRenderer.js
 export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   document.body.classList.add('builder-mode');
+  if (!document.querySelector('link[data-builder-theme]')) {
+    const theme = window.ACTIVE_THEME || 'default';
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = `/themes/${theme}/theme.css`;
+    link.dataset.builderTheme = '';
+    document.head.appendChild(link);
+  }
   // Temporary patch: larger default widget height
   const DEFAULT_ROWS = 20; // around 100px with 5px grid cells
   const ICON_MAP = {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ El Psy Kongroo
   templates, notification hub and widget templates.
 - Corrected instructions to open the Notification Hub using the Blogposter logo
   instead of the bell icon.
+- Fixed builder page missing global theme injection, ensuring widgets inherit
+  active theme styles.
 
 ## [0.5.0] – 2025-06-11
 -- **Breaking change:** delete your existing database and reinitialize BlogposterCMS after upgrading for the new features to work.


### PR DESCRIPTION
## Summary
- inject theme link when builder initializes so widgets use active theme
- document theme injection fix in changelog

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_684a4867d2e483289c8d06c5bd8bd1ec