### PR TITLE
Remove admin home sidebar

### DIFF
--- a/BlogposterCMS/mother/modules/plainSpace/config/adminPages.js
+++ b/BlogposterCMS/mother/modules/plainSpace/config/adminPages.js
@@ -9,7 +9,7 @@ module.exports.ADMIN_PAGES = [
     config: {
       layout: {
         header: 'top-header',
-        sidebar: 'default-sidebar',
+        sidebar: 'empty-sidebar',
         inheritsLayout: true
       },
       widgets: ['systemInfo', 'activityLog']

--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -185,7 +185,7 @@ function ensureLayout(layout = {}, lane = 'public') {
     scope.appendChild(mainContent);
   }
 
-  if (inherit || layout.sidebar) {
+  if ((inherit || layout.sidebar) && layout.sidebar !== 'empty-sidebar') {
     if (!document.getElementById('sidebar')) {
       const sidebar = document.createElement('aside');
       sidebar.id = 'sidebar';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Removed content sidebar from admin home screen.
 - Documentation updates for v0.5.0 features: permission groups, layout
   templates, notification hub and widget templates.
 - Corrected instructions to open the Notification Hub using the Blogposter logo


### PR DESCRIPTION
## Summary
- remove default sidebar from admin home page config
- skip sidebar creation when layout specifies `empty-sidebar`
- document sidebar removal in changelog

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_684a48e5d8788328b7788a56e8ad4009