### PR TITLE
Add inline editing for page list titles

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/defaultwidgets/pageList.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/defaultwidgets/pageList.js
@@ -143,7 +143,7 @@ function renderPages(pages, list) {
     li.innerHTML = `
       <div class="page-details">
         <div class="page-name-row">
-          <span class="page-name">${page.title}</span>
+          <span class="page-name" contenteditable="true">${page.title}</span>
           <span class="page-actions">
               ${page.is_start
                 ? '<span class="home-indicator" title="Current home page">Home</span>'
@@ -162,6 +162,24 @@ function renderPages(pages, list) {
         </div>
       </div>
     `;
+
+    // Inline title editing
+    const titleEl = li.querySelector('.page-name');
+    titleEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        titleEl.blur();
+      }
+    });
+    titleEl.addEventListener('blur', (e) => {
+      const newTitle = e.target.textContent.trim();
+      if (newTitle && newTitle !== page.title) {
+        updateTitle(page, newTitle);
+        page.title = newTitle;
+      } else {
+        titleEl.textContent = page.title;
+      }
+    });
 
     // Inline slug editing
     const slugEl = li.querySelector('.page-slug');
@@ -231,6 +249,30 @@ async function updateSlug(page, slug) {
   } catch (err) {
     console.error('updateSlug failed', err);
     alert('Failed to update slug: ' + err.message);
+  }
+}
+
+async function updateTitle(page, title) {
+  try {
+    await meltdownEmit('updatePage', {
+      jwt: window.ADMIN_TOKEN,
+      moduleName: 'pagesManager',
+      moduleType: 'core',
+      pageId: page.id,
+      slug: page.slug,
+      status: page.status,
+      seo_Image: page.seo_image,
+      parent_id: page.parent_id,
+      is_content: page.is_content,
+      lane: page.lane,
+      language: page.language,
+      title,
+      meta: page.meta
+    });
+    page.title = title;
+  } catch (err) {
+    console.error('updateTitle failed', err);
+    alert('Failed to update title: ' + err.message);
   }
 }
 

--- a/BlogposterCMS/public/assets/scss/pages/_pages.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_pages.scss
@@ -130,6 +130,16 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding: 2px 6px 2px 0;
+  border-radius: 6px;
+  outline: none;
+  border: 1px solid transparent;
+  transition: border 0.18s;
+  &[contenteditable="true"]:focus {
+    border: 1px solid #ddd;
+    background: #fff0ff;
+    color: #181818;
+  }
 }
 
 .page-actions {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ El Psy Kongroo
   templates, notification hub and widget templates.
 - Corrected instructions to open the Notification Hub using the Blogposter logo
   instead of the bell icon.
+- Page list widget now lets admins edit page titles and slugs inline; press
+  Enter or click outside to save changes.
 
 ## [0.5.0] – 2025-06-11
 -- **Breaking change:** delete your existing database and reinitialize BlogposterCMS after upgrading for the new features to work.


### PR DESCRIPTION
## Summary
- enable editing page titles inline inside page list widget
- add helper to update page title via API
- style editable titles in the SCSS
- note new feature in `CHANGELOG.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a4967402c83289eef783cab8026e7