### PR TITLE
Fix pageStats widget token

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/defaultwidgets/pageStats.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/defaultwidgets/pageStats.js
@@ -2,6 +2,7 @@
 export async function render(el) {
     try {
       const res = await meltdownEmit('getAllPages', {
+        jwt: window.ADMIN_TOKEN,
         moduleName: 'pagesManager',
         moduleType: 'core'
       });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ El Psy Kongroo
   templates, notification hub and widget templates.
 - Corrected instructions to open the Notification Hub using the Blogposter logo
   instead of the bell icon.
+- Fixed page statistics widget to display actual page counts on the admin
+  dashboard.
 
 ## [0.5.0] – 2025-06-11
 -- **Breaking change:** delete your existing database and reinitialize BlogposterCMS after upgrading for the new features to work.


### PR DESCRIPTION
## Summary
- fix page statistics widget to pass ADMIN_TOKEN so real numbers are shown
- document the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a49a757188328894499fe5944b03b