### PR TITLE
Add builder preview mode

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -800,6 +800,13 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     '<img src="/assets/icons/save.svg" alt="Save" />';
   topBar.appendChild(saveBtn);
 
+  const previewBtn = document.createElement('button');
+  previewBtn.id = 'previewLayoutBtn';
+  previewBtn.className = 'builder-preview-btn';
+  previewBtn.innerHTML = window.featherIcon ? window.featherIcon('eye') :
+    '<img src="/assets/icons/eye.svg" alt="Preview" />';
+  topBar.appendChild(previewBtn);
+
   const appScope = document.querySelector('.app-scope');
   const mainContent = document.querySelector('.main-content');
   if (appScope && mainContent) {
@@ -842,6 +849,16 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     } catch (err) {
       console.error('[Builder] saveLayoutTemplate error', err);
       alert('Save failed: ' + err.message);
+    }
+  });
+
+  previewBtn.addEventListener('click', () => {
+    const active = document.body.classList.toggle('preview-mode');
+    if (window.featherIcon) {
+      previewBtn.innerHTML = window.featherIcon(active ? 'eye-off' : 'eye');
+    } else {
+      const icon = active ? 'eye-off' : 'eye';
+      previewBtn.innerHTML = `<img src="/assets/icons/${icon}.svg" alt="Preview" />`;
     }
   });
 }

--- a/BlogposterCMS/public/assets/plainspace/admin/partials/builder-header.html
+++ b/BlogposterCMS/public/assets/plainspace/admin/partials/builder-header.html
@@ -4,4 +4,8 @@
     <img src="/assets/icons/save.svg" class="icon" alt="Save" />
     Save Layout
   </button>
+  <button id="previewLayoutBtn" class="button builder-preview-btn">
+    <img src="/assets/icons/eye.svg" class="icon" alt="Preview" />
+    Preview
+  </button>
 </header>

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -14,7 +14,8 @@
 }
 
 .builder-header .builder-back-btn,
-.builder-header .builder-save-btn {
+.builder-header .builder-save-btn,
+.builder-header .builder-preview-btn {
   background: transparent;
   border: none;
   cursor: pointer;
@@ -250,6 +251,24 @@ body.builder-mode #builderGrid {
 body.builder-mode #top-header,
 body.builder-mode #main-header {
   display: none;
+}
+
+body.preview-mode .builder-sidebar,
+body.preview-mode .widget-code-editor,
+body.preview-mode .widget-options-menu,
+body.preview-mode .grid-stack-item .widget-remove,
+body.preview-mode .grid-stack-item .widget-edit,
+body.preview-mode .grid-stack-item .widget-menu {
+  display: none !important;
+}
+
+body.preview-mode .builder-header .builder-save-btn,
+body.preview-mode .builder-header .layout-info {
+  display: none;
+}
+
+body.preview-mode #builderGrid {
+  pointer-events: none;
 }
 
 .grid-stack-item[gs-locked="true"] > .ui-resizable-handle {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Added preview mode toggle to the page builder for quick layout previews.
 - Redesigned media explorer with a grid layout and folder navigation.
 - Removed content sidebar from admin home screen.
 - Admin dashboard now displays the current page title in the header and browser tab.


### PR DESCRIPTION
## Summary
- add preview button to builder header
- implement preview mode toggle
- hide editing UI elements in preview
- document new builder preview feature in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a54aa23a883289ce6ea8aa5e28fcd