### PR TITLE
Fix builder menu overlap with Quill editor

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -138,6 +138,7 @@
   border: none;
   padding: 2px;
   cursor: pointer;
+  z-index: 1000;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
@@ -155,6 +156,7 @@
   border: none;
   padding: 2px;
   cursor: pointer;
+  z-index: 1000;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;

--- a/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
@@ -11,7 +11,7 @@
 
 .text-block-editor-overlay {
   position: absolute;
-  z-index: 1000;
+  z-index: 950; // sits above widget content but below builder controls
   width: 100%;
   height: 100%;
   display: none;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Quill text editor overlay appears above widget text but stays below menu buttons.
+- Quill editor overlay no longer blocks builder menu buttons.
 - Scoped theme injection in builder mode for live preview without altering the builder UI.
 - Removed global theme injection in builder mode to protect the editor UX.
 - Redesigned media explorer with a grid layout and folder navigation.


### PR DESCRIPTION
## Summary
- keep widget menu buttons above Quill editor overlay so they stay clickable
- document the fix in the changelog
- adjust Quill overlay z-index to ensure it sits above widget text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a5815d69c832894ae9922f4518596