### PR TITLE
Refactor page stats widget to use real data

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/defaultwidgets/pageStats.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/defaultwidgets/pageStats.js
@@ -1,30 +1,45 @@
 // public/assets/admin/defaulwidgets/pageStats.js
 export async function render(el) {
-    try {
-      const res = await meltdownEmit('getAllPages', {
-        jwt: window.ADMIN_TOKEN,
+  try {
+    const jwt = window.ADMIN_TOKEN;
+
+    const [publicRes, adminRes] = await Promise.all([
+      meltdownEmit('getPagesByLane', {
+        jwt,
         moduleName: 'pagesManager',
-        moduleType: 'core'
-      });
-  
-      const pages = res?.data ?? [];
-  
-      const published = pages.filter(p => p.status === 'published').length;
-      const draft = pages.filter(p => p.status === 'draft').length;
-      const total = pages.length;
-  
-      el.innerHTML = `
-        <div class="page-stats-widget">
-          <h3>Page Statistics</h3>
-          <ul>
-            <li>Total Pages: ${total}</li>
-            <li>Published: ${published}</li>
-            <li>Drafts: ${draft}</li>
-          </ul>
-        </div>
-      `;
-    } catch (err) {
-      el.innerHTML = `<div class="error">Error loading stats: ${err.message}</div>`;
-    }
+        moduleType: 'core',
+        lane: 'public'
+      }),
+      meltdownEmit('getPagesByLane', {
+        jwt,
+        moduleName: 'pagesManager',
+        moduleType: 'core',
+        lane: 'admin'
+      })
+    ]);
+
+    const toArr = r => (Array.isArray(r) ? r : r?.data ?? []);
+    const publicPages = toArr(publicRes);
+    const adminPages = toArr(adminRes);
+
+    const total = publicPages.length + adminPages.length;
+    const published = publicPages.filter(p => p.status === 'published').length;
+    const draft = publicPages.filter(p => p.status === 'draft').length;
+    const adminCount = adminPages.length;
+
+    el.innerHTML = `
+      <div class="page-stats-widget">
+        <h3>Page Statistics</h3>
+        <ul>
+          <li>Total Pages: ${total}</li>
+          <li>Public Published: ${published}</li>
+          <li>Public Drafts: ${draft}</li>
+          <li>Admin Pages: ${adminCount}</li>
+        </ul>
+      </div>
+    `;
+  } catch (err) {
+    el.innerHTML = `<div class="error">Error loading stats: ${err.message}</div>`;
   }
+}
   

--- a/BlogposterCMS/public/assets/scss/pages/_pages.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_pages.scss
@@ -203,3 +203,26 @@
     opacity: 1;
   }
 }
+
+// Stats widget
+.page-stats-widget {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.07);
+  padding: 20px;
+  margin: 0 auto;
+  width: 100%;
+  font-family: var(--font-body);
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  li {
+    color: #555;
+    font-size: 0.95rem;
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Refactored page statistics widget to show live counts by lane.
 - Quill text editor overlay appears above widget text but stays below menu buttons.
 - Quill editor overlay no longer blocks builder menu buttons.
 - Added preview mode toggle to the page builder for quick layout previews.


### PR DESCRIPTION
## Summary
- fetch page stats by lane and display counts
- style `page-stats-widget`
- document the change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ac5916be08328928ba9b5fb5531d8