### PR TITLE
Show builder version notice

### DIFF
--- a/BlogposterCMS/app.js
+++ b/BlogposterCMS/app.js
@@ -88,6 +88,19 @@ const jwtExpiryConfig = {
 const ACTIVE_THEME = (process.env.ACTIVE_THEME || 'default')
   .replace(/[^a-zA-Z0-9_-]/g, '') || 'default';
 
+let PLAINSPACE_VERSION = '';
+try {
+  const infoPath = path.join(__dirname, 'mother', 'modules', 'plainSpace', 'moduleInfo.json');
+  if (fs.existsSync(infoPath)) {
+    const info = JSON.parse(fs.readFileSync(infoPath, 'utf8'));
+    if (info && typeof info.version === 'string') {
+      PLAINSPACE_VERSION = info.version;
+    }
+  }
+} catch (err) {
+  console.warn('[SERVER] Failed to load PlainSpace moduleInfo:', err.message);
+}
+
 //───────────────────────────────────────────────────────────────────────────
 // Load local secret overrides (optional .secrets.js files)
 //───────────────────────────────────────────────────────────────────────────
@@ -550,6 +563,7 @@ app.get('/admin/*', pageLimiter, csrfProtection, async (req, res, next) => {
         window.PAGE_SLUG   = ${JSON.stringify(slug)};
         window.ADMIN_TOKEN = ${JSON.stringify(adminJwt)};
         window.ACTIVE_THEME = ${JSON.stringify(ACTIVE_THEME)};
+        window.PLAINSPACE_VERSION = ${JSON.stringify(PLAINSPACE_VERSION)};
         window.NONCE       = ${JSON.stringify(nonce)};
       </script>
     </head>`;
@@ -692,6 +706,7 @@ app.get('/:slug?', pageLimiter, async (req, res, next) => {
       window.LANE    = ${JSON.stringify(lane)};
       window.PUBLIC_TOKEN = ${JSON.stringify(token)};
       window.ACTIVE_THEME = ${JSON.stringify(ACTIVE_THEME)};
+      window.PLAINSPACE_VERSION = ${JSON.stringify(PLAINSPACE_VERSION)};
       window.NONCE  = ${JSON.stringify(nonce)};
     </script>`;
     html = html.replace('</head>', inject + '</head>');

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -1,4 +1,5 @@
 // public/assets/plainspace/admin/builderRenderer.js
+
 export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   document.body.classList.add('builder-mode');
   // Builder widgets load the active theme inside their shadow roots.
@@ -886,4 +887,20 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       previewBtn.innerHTML = `<img src="/assets/icons/${icon}.svg" alt="Preview" />`;
     }
   });
+
+  let versionEl = document.getElementById('builderVersion');
+  if (!versionEl) {
+    versionEl = document.createElement('div');
+    versionEl.id = 'builderVersion';
+    versionEl.className = 'builder-version';
+    document.body.appendChild(versionEl);
+  }
+
+  const builderVersion = window.PLAINSPACE_VERSION;
+
+  if (builderVersion) {
+    versionEl.textContent = `${builderVersion} builder still in alpha expect breaking changes`;
+  } else {
+    versionEl.textContent = 'builder still in alpha expect breaking changes';
+  }
 }

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -301,3 +301,14 @@ body.preview-mode #builderGrid {
   z-index: 100;
 }
 
+.builder-version {
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  padding: 2px 4px;
+  font-size: 10px;
+  color: var(--color-text);
+  background: rgba(255, 255, 255, 0.6);
+  pointer-events: none;
+  z-index: 50;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Builder footer shows the Plainspace version using a server-injected variable and warns the builder is in alpha.
 - Quill text editor overlay appears above widget text but stays below menu buttons.
 - Quill editor overlay no longer blocks builder menu buttons.
 - Added preview mode toggle to the page builder for quick layout previews.


### PR DESCRIPTION
## Summary
- inject Plainspace version as global variable
- show builder version notice using the global variable
- note builder version notice change in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ac4c133b08328a903f12054e36690