### PR TITLE
Implement editable widget layout

### DIFF
--- a/BlogposterCMS/public/assets/js/contentHeaderActions.js
+++ b/BlogposterCMS/public/assets/js/contentHeaderActions.js
@@ -17,7 +17,7 @@ export function initContentHeader() {
   if (!editToggle) return;
 
   let editing = false;
-  editToggle.addEventListener('click', () => {
+  editToggle.addEventListener('click', async () => {
     const grid = window.adminGrid;
     if (!grid || typeof grid.setStatic !== 'function') return;
     editing = !editing;
@@ -25,6 +25,9 @@ export function initContentHeader() {
     editToggle.src = editing ? '/assets/icons/check.svg' : '/assets/icons/edit.svg';
     editToggle.classList.add('spin');
     setTimeout(() => editToggle.classList.remove('spin'), 300);
+    if (!editing && typeof window.saveAdminLayout === 'function') {
+      try { await window.saveAdminLayout(); } catch(e) { console.error(e); }
+    }
   });
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Content header edit icon now toggles widget drag mode and saves layout when exiting edit mode. Widgets remain fixed by default.
 - Builder footer shows the Plainspace version using a server-injected variable and warns the builder is in alpha.
 - Refactored page statistics widget to show live counts by lane.
 - Quill text editor overlay appears above widget text but stays below menu buttons.


### PR DESCRIPTION
## Summary
- lock admin widgets by default
- allow editing via edit icon and save layout on exit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c3b57f794832884e71c2d99d5d107