### PR TITLE
Improve modules list widget design

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/modulesListWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/modulesListWidget.js
@@ -59,9 +59,58 @@ export async function render(el) {
       installed.forEach(m => {
         const li = document.createElement('li');
         const info = m.module_info || {};
-        const desc = info.description ? ` - ${info.description}` : '';
-        const status = m.is_active ? '' : ' (inactive)';
-        li.textContent = `${m.module_name}${desc}${status}`;
+        const name = info.moduleName || m.module_name;
+        const version = info.version ? `v${info.version}` : '';
+        const developer = info.developer || 'Unknown Developer';
+        const desc = info.description || '';
+
+        const details = document.createElement('div');
+        details.className = 'module-details';
+
+        const nameRow = document.createElement('div');
+        nameRow.className = 'module-name-row';
+
+        const nameEl = document.createElement('span');
+        nameEl.className = 'module-name';
+        nameEl.textContent = name;
+
+        const actions = document.createElement('span');
+        actions.className = 'module-actions';
+
+        const toggleBtn = document.createElement('button');
+        toggleBtn.className = 'module-toggle-btn';
+        toggleBtn.textContent = m.is_active ? 'Deactivate' : 'Activate';
+        toggleBtn.addEventListener('click', async () => {
+          try {
+            await meltdownEmit(m.is_active ? 'deactivateModuleInRegistry' : 'activateModuleInRegistry', {
+              jwt,
+              moduleName: 'moduleLoader',
+              moduleType: 'core',
+              targetModuleName: m.module_name
+            });
+            m.is_active = !m.is_active;
+            toggleBtn.textContent = m.is_active ? 'Deactivate' : 'Activate';
+          } catch (err) {
+            alert('Error: ' + err.message);
+          }
+        });
+
+        actions.appendChild(toggleBtn);
+        nameRow.appendChild(nameEl);
+        nameRow.appendChild(actions);
+
+        const meta = document.createElement('div');
+        meta.className = 'module-meta';
+        const pieces = [];
+        if (version) pieces.push(version);
+        if (developer) pieces.push(developer);
+        if (desc) pieces.push(desc);
+        meta.textContent = pieces.join(' \u2022 ');
+
+        details.appendChild(nameRow);
+        details.appendChild(meta);
+        li.appendChild(details);
+
         installedList.appendChild(li);
       });
     }
@@ -79,8 +128,35 @@ export async function render(el) {
       system.forEach(m => {
         const li = document.createElement('li');
         const info = m.moduleInfo || {};
-        const desc = info.description ? ` - ${info.description}` : '';
-        li.textContent = `${m.module_name}${desc}`;
+        const name = info.moduleName || m.module_name;
+        const version = info.version ? `v${info.version}` : '';
+        const developer = info.developer || 'Unknown Developer';
+        const desc = info.description || '';
+
+        const details = document.createElement('div');
+        details.className = 'module-details';
+
+        const nameRow = document.createElement('div');
+        nameRow.className = 'module-name-row';
+
+        const nameEl = document.createElement('span');
+        nameEl.className = 'module-name';
+        nameEl.textContent = name;
+
+        nameRow.appendChild(nameEl);
+
+        const meta = document.createElement('div');
+        meta.className = 'module-meta';
+        const pieces = [];
+        if (version) pieces.push(version);
+        if (developer) pieces.push(developer);
+        if (desc) pieces.push(desc);
+        meta.textContent = pieces.join(' \u2022 ');
+
+        details.appendChild(nameRow);
+        details.appendChild(meta);
+        li.appendChild(details);
+
         systemList.appendChild(li);
       });
     }

--- a/BlogposterCMS/public/assets/scss/pages/_modules.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_modules.scss
@@ -41,3 +41,34 @@
   border-bottom: 2px solid currentColor;
   font-weight: bold;
 }
+
+.module-details {
+  @extend .page-details;
+}
+
+.module-name-row {
+  @extend .page-name-row;
+}
+
+.module-name {
+  @extend .page-name;
+}
+
+.module-actions {
+  @extend .page-actions;
+}
+
+.module-meta {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  color: #555;
+}
+
+.module-toggle-btn {
+  background: #f6f6f6;
+  border: none;
+  border-radius: 5px;
+  padding: 2px 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Redesigned modules list widget with activation toggles and module details.
 - Builder footer shows the Plainspace version using a server-injected variable and warns the builder is in alpha.
 - Login route now redirects authenticated users and disables caching.
 - Refactored page statistics widget to show live counts by lane.


### PR DESCRIPTION
## Summary
- redesign modules list widget similar to the page list widget
- show module details from `moduleInfo.json`
- add activation toggle for installed modules
- extend styles for the new widget design
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c3e946f3c8328a0ba409183dd0a4a