### PR TITLE
Add user color preference

### DIFF
--- a/BlogposterCMS/mother/modules/userManagement/index.js
+++ b/BlogposterCMS/mother/modules/userManagement/index.js
@@ -12,6 +12,7 @@ const {
   ensureUserManagementSchemaAndTables,
   ensureDefaultRoles,
   ensureDefaultPermissions,
+  ensureUserColorField,
   ensureFirstUserIsAdmin
 } = require('./userInitService');
 
@@ -41,6 +42,7 @@ async function initialize({ motherEmitter, app, dbConfig, isCore, jwt }) {
     await ensureDefaultRoles(motherEmitter, jwt);
     // D) Ensure default permissions for system to work
     await ensureDefaultPermissions(motherEmitter, jwt);
+    await ensureUserColorField(motherEmitter, jwt);
 
     await ensureFirstUserIsAdmin(motherEmitter, jwt);
 

--- a/BlogposterCMS/mother/modules/userManagement/userCrudEvents.js
+++ b/BlogposterCMS/mother/modules/userManagement/userCrudEvents.js
@@ -55,6 +55,7 @@ function setupUserCrudEvents(motherEmitter) {
       website,
       avatarUrl,
       bio,
+      uiColor,
       role
     } = payload || {};
 
@@ -94,6 +95,7 @@ function setupUserCrudEvents(motherEmitter) {
         website     : website     || null,
         avatar_url  : avatarUrl   || null,
         bio         : bio         || null,
+        ui_color    : uiColor     || null,
         token_version: 0,
         created_at  : new Date().toISOString(),
         updated_at  : new Date().toISOString()
@@ -381,7 +383,8 @@ function setupUserCrudEvents(motherEmitter) {
       newCompany,
       newWebsite,
       newAvatarUrl,
-      newBio
+      newBio,
+      newUiColor
     } = payload || {};
 
     if (!jwt || moduleName !== 'userManagement' || moduleType !== 'core') {
@@ -414,6 +417,7 @@ function setupUserCrudEvents(motherEmitter) {
       if (newWebsite)      dataToUpdate.website      = newWebsite;
       if (newAvatarUrl)    dataToUpdate.avatar_url   = newAvatarUrl;
       if (newBio)          dataToUpdate.bio          = newBio;
+      if (newUiColor)     dataToUpdate.ui_color     = newUiColor;
 
       // Password?
       if (newPassword) {

--- a/BlogposterCMS/mother/modules/userManagement/userInitService.js
+++ b/BlogposterCMS/mother/modules/userManagement/userInitService.js
@@ -138,6 +138,19 @@ async function ensureDefaultPermissions(motherEmitter, jwt) {
   console.log('[USER SERVICE] Default permissions ensured.');
 }
 
+async function ensureUserColorField(motherEmitter, jwt) {
+  console.log('[USER SERVICE] Ensuring ui_color field…');
+  await emitAsync(motherEmitter, 'dbUpdate', {
+    jwt,
+    moduleName: 'userManagement',
+    moduleType: 'core',
+    table: '__rawSQL__',
+    where: {},
+    data: { rawSQL: 'ADD_USER_FIELD', fieldName: 'ui_color', fieldType: 'VARCHAR(16)' }
+  });
+  console.log('[USER SERVICE] ui_color field ensured.');
+}
+
 /* ============ 3) Self‑Healing: erster User = Admin ============ */
 async function ensureFirstUserIsAdmin(motherEmitter, jwt) {
   console.log('[USER SERVICE] Verifying that at least one admin exists…');
@@ -210,5 +223,6 @@ module.exports = {
   ensureUserManagementSchemaAndTables,
   ensureDefaultRoles,
   ensureDefaultPermissions,
+  ensureUserColorField,
   ensureFirstUserIsAdmin          // neue Routine wird mit‑exportiert
 };

--- a/BlogposterCMS/public/admin.html
+++ b/BlogposterCMS/public/admin.html
@@ -38,6 +38,7 @@
 
   <!-- 3) Token loader (stores window.ADMIN_TOKEN / PUBLIC_TOKEN) -->
   <script type="module" src="/assets/js/tokenLoader.js"></script>
+  <script type="module" src="/assets/js/userColor.js"></script>
 
   <!-- Preload page data for editor widgets -->
   <script type="module" src="/assets/js/pageDataLoader.js"></script>

--- a/BlogposterCMS/public/assets/js/userColor.js
+++ b/BlogposterCMS/public/assets/js/userColor.js
@@ -1,0 +1,28 @@
+export async function applyUserColor() {
+  const jwt = window.ADMIN_TOKEN;
+  if (!jwt || !window.meltdownEmit) return;
+  try {
+    const decoded = await window.meltdownEmit('validateToken', {
+      jwt,
+      moduleName: 'auth',
+      moduleType: 'core',
+      tokenToValidate: jwt
+    });
+    const userId = decoded?.userId;
+    if (!userId) return;
+    const res = await window.meltdownEmit('getUserDetailsById', {
+      jwt,
+      moduleName: 'userManagement',
+      moduleType: 'core',
+      userId
+    });
+    const user = res?.data ?? res;
+    if (user && user.ui_color) {
+      document.documentElement.style.setProperty('--user-color', user.ui_color);
+    }
+  } catch (err) {
+    console.error('[userColor] Failed to set user color', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', applyUserColor);

--- a/BlogposterCMS/public/assets/plainspace/admin/userEditWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/userEditWidget.js
@@ -31,24 +31,43 @@ export async function render(el) {
       'company',
       'website',
       'avatar_url',
-      'bio'
+      'bio',
+      'ui_color'
     ];
     const inputs = {};
     const container = document.createElement('div');
     container.className = 'user-edit-widget';
 
+    const colorChoices = ['#008080', '#FF00FF', '#FFA500', '#00A2FF', '#8A2BE2', '#FF4500'];
+
     fields.forEach(f => {
       const field = document.createElement('div');
       field.className = 'field';
 
-      const input = document.createElement(f === 'bio' ? 'textarea' : 'input');
-      const id = `ue-${f}`;
-      if (input.tagName === 'INPUT') {
+      let input;
+      if (f === 'bio') {
+        input = document.createElement('textarea');
+      } else if (f === 'ui_color') {
+        input = document.createElement('select');
+        colorChoices.forEach(c => {
+          const opt = document.createElement('option');
+          opt.value = c;
+          opt.textContent = c;
+          opt.style.backgroundColor = c;
+          opt.style.color = '#fff';
+          input.appendChild(opt);
+        });
+      } else {
+        input = document.createElement('input');
         input.type = 'text';
       }
+
+      const id = `ue-${f}`;
       input.id = id;
-      input.placeholder = ' ';
+      if (f !== 'ui_color') input.placeholder = ' ';
       input.value = user[f] || '';
+      if (f === 'ui_color' && !user[f]) input.dataset.empty = 'true';
+      input.addEventListener('change', () => { if (f === 'ui_color') delete input.dataset.empty; });
       inputs[f] = input;
 
       const label = document.createElement('label');
@@ -95,7 +114,8 @@ export async function render(el) {
         newCompany: inputs.company.value.trim(),
         newWebsite: inputs.website.value.trim(),
         newAvatarUrl: inputs.avatar_url.value.trim(),
-        newBio: inputs.bio.value
+        newBio: inputs.bio.value,
+        newUiColor: inputs.ui_color.value
       };
       if (passInput.value.trim()) {
         payload.newPassword = passInput.value.trim();

--- a/BlogposterCMS/public/assets/scss/_variables.scss
+++ b/BlogposterCMS/public/assets/scss/_variables.scss
@@ -8,7 +8,9 @@
   --color-secondary-light: #F5F5F5; // Hellgrau für Inputs (nicht für Cards)
   --color-text: #222222; // Dunkler für mehr Kontrast
   --color-white: #FFFFFF;
-  --gradient-primary: linear-gradient(90deg, #008080, #FF00FF, #FFA500);
+  --user-color: #008080; // User-selected accent color
+  --color-primary: var(--user-color);
+  --gradient-primary: linear-gradient(90deg, var(--user-color), #FF00FF, #FFA500);
   --shadow-card: 0 1px 28px rgba(0,0,0,0.07);
 
   // Typography

--- a/BlogposterCMS/public/assets/scss/components/_page-editor.scss
+++ b/BlogposterCMS/public/assets/scss/components/_page-editor.scss
@@ -29,7 +29,8 @@
 .page-settings-widget .field textarea,
 .seo-image-widget .field input,
 .user-edit-widget .field input,
-.user-edit-widget .field textarea {
+.user-edit-widget .field textarea,
+.user-edit-widget select {
   width: 100%;
   padding: 1.5rem 0.75rem 0.5rem;
   border: none;
@@ -47,7 +48,8 @@
 .page-settings-widget .field textarea:focus,
 .seo-image-widget .field input:focus,
 .user-edit-widget .field input:focus,
-.user-edit-widget .field textarea:focus {
+.user-edit-widget .field textarea:focus,
+.user-edit-widget select:focus {
   outline: none;
   border-bottom: 2px solid #008080;
 }
@@ -80,7 +82,9 @@
 .user-edit-widget .field input:focus + label,
 .user-edit-widget .field input:not(:placeholder-shown) + label,
 .user-edit-widget .field textarea:focus + label,
-.user-edit-widget .field textarea:not(:placeholder-shown) + label {
+.user-edit-widget .field textarea:not(:placeholder-shown) + label,
+.user-edit-widget select:focus + label,
+.user-edit-widget select:not([data-empty="true"]) + label {
   top: 0.25rem;
   font-size: 0.75rem;
   color: #008080;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Users can now select a personal UI color that sets the `--user-color` CSS variable across the dashboard.
 - Theme styles in the builder no longer change menu buttons; active theme now only affects widget previews and background.
 - Dynamic action button now hides unless configured and shows as a circle with hover and click animations.
 - Redesigned modules list widget with activation toggles and module details.


### PR DESCRIPTION
## Summary
- allow users to pick a `ui_color` for personalized accent
- ensure new `ui_color` column is present during initialization
- expose the color through user edit widget and update APIs
- use `--user-color` CSS variable for gradients and icons
- apply the selected color when the admin panel loads
- document change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c4709a0b083289180409e6a893445