### PR TITLE
Add hover border to builder widgets

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -233,9 +233,20 @@
   margin-right: auto;
 }
 
+
 .grid-stack-item .widget-remove .icon {
   width: 16px;
   height: 16px;
+}
+
+// Highlight widget wrapper on hover using the active user's color
+.grid-stack-item {
+  border: 2px solid transparent;
+  transition: border-color 0.2s ease;
+}
+
+.grid-stack-item:hover {
+  border-color: var(--color-primary);
 }
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Builder widgets now show a border in the active user's color on hover.
 - Users can now select a personal UI color that sets the `--user-color` CSS variable across the dashboard.
 - Theme styles in the builder no longer change menu buttons; active theme now only affects widget previews and background.
 - Dynamic action button now hides unless configured and shows as a circle with hover and click animations.


### PR DESCRIPTION
## Summary
- highlight widget wrappers with a colored border when hovering inside the builder
- document new widget hover effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c4bf2a9208328a433991827fb6ed1