### PR TITLE
Add widget action toolbar

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -166,8 +166,8 @@
 
 .grid-stack-item:hover .widget-menu,
 .grid-stack-item:hover .widget-remove {
-  opacity: 1;
-  pointer-events: auto;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .widget-options-menu {
@@ -196,6 +196,27 @@
 
 .widget-options-menu button:hover {
   background: var(--color-light-gray, #f0f0f0);
+}
+
+.widget-action-bar {
+  position: absolute;
+  background: var(--color-white);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: var(--shadow-card);
+  display: flex;
+  gap: 4px;
+  padding: 2px;
+  z-index: 1000;
+}
+
+.widget-action-bar button {
+  background: transparent;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 
 .widget-code-editor {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widget action buttons now appear as a popup toolbar when selecting a widget, offering lock, duplicate and delete options.
 - Users can now select a personal UI color that sets the `--user-color` CSS variable across the dashboard.
 - Theme styles in the builder no longer change menu buttons; active theme now only affects widget previews and background.
 - Dynamic action button now hides unless configured and shows as a circle with hover and click animations.


### PR DESCRIPTION
## Summary
- add clickable action bar in builder renderer
- style action bar and disable old hover buttons
- document widget action toolbar in changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c4d1373cc8328b35a4940f71d7844