### PR TITLE
Limit widget highlight to builder mode

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -153,8 +153,11 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   delBtn.addEventListener('click', e => {
     e.stopPropagation();
     if (!activeWidgetEl) return;
-    grid.removeWidget(activeWidgetEl);
+    const target = activeWidgetEl;
+    target.classList.remove('selected');
+    grid.removeWidget(target);
     actionBar.style.display = 'none';
+    activeWidgetEl = null;
     if (pageId) saveCurrentLayout();
   });
   const genId = () => `w${Math.random().toString(36).slice(2,8)}`;
@@ -528,6 +531,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       return;
     }
     actionBar.style.display = 'none';
+    activeWidgetEl.classList.remove('selected');
     activeWidgetEl = null;
   });
 
@@ -748,7 +752,9 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       if (!e.target.closest('.grid-stack-item-content')) return;
       if (e.target.closest('.widget-action-bar')) return;
       e.stopPropagation();
+      if (activeWidgetEl) activeWidgetEl.classList.remove('selected');
       activeWidgetEl = el;
+      activeWidgetEl.classList.add('selected');
       const locked = el.getAttribute('gs-locked') === 'true';
       setLockIcon(locked);
       actionBar.style.display = 'flex';

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -261,12 +261,13 @@
 }
 
 // Highlight widget wrapper on hover using the active user's color
-.grid-stack-item {
+.builder-mode .grid-stack-item {
   border: 2px solid transparent;
   transition: border-color 0.2s ease;
 }
 
-.grid-stack-item:hover {
+.builder-mode .grid-stack-item:hover,
+.builder-mode .grid-stack-item.selected {
   border-color: var(--user-color);
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ El Psy Kongroo
 - Added /install route for first-time setup collecting admin details.
 - Widget action buttons now appear as a popup toolbar when selecting a widget, offering lock, duplicate and delete options.
 - Builder widgets now show a border in the active user's color on hover.
+- Builder widget border is now only visible in builder mode when hovering or selecting a widget.
 - Users can now select a personal UI color that sets the `--user-color` CSS variable across the dashboard.
 - Theme styles in the builder no longer change menu buttons; active theme now only affects widget previews and background.
 - Dynamic action button now hides unless configured and shows as a circle with hover and click animations.


### PR DESCRIPTION
## Summary
- show widget borders only within builder mode
- highlight active widget when clicked
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c597897e883289bf844e1233adad0