### PR TITLE
Fix admin install redirect when no users

### DIFF
--- a/BlogposterCMS/app.js
+++ b/BlogposterCMS/app.js
@@ -489,21 +489,29 @@ app.get('/admin/home', pageLimiter, csrfProtection, async (req, res) => {
     const publicJwt = await new Promise((resolve, reject) => {
       motherEmitter.emit(
         'issuePublicToken',
-        { purpose: 'login', moduleName: 'auth' },
+        { purpose: 'firstInstallCheck', moduleName: 'auth' },
         (err, tok) => err ? reject(err) : resolve(tok)
       );
     });
 
-    const userCount = await new Promise((resolve, reject) => {
-      motherEmitter.emit(
-        'getUserCount',
-        { jwt: publicJwt, moduleName: 'userManagement', moduleType: 'core' },
-        (err, count = 0) => err ? reject(err) : resolve(count)
-      );
-    });
+    const [installVal, userCount] = await Promise.all([
+      new Promise((resolve, reject) => {
+        motherEmitter.emit(
+          'getPublicSetting',
+          { jwt: publicJwt, moduleName: 'settingsManager', moduleType: 'core', key: 'FIRST_INSTALL_DONE' },
+          (err, val) => err ? reject(err) : resolve(val)
+        );
+      }),
+      new Promise((resolve, reject) => {
+        motherEmitter.emit(
+          'getUserCount',
+          { jwt: publicJwt, moduleName: 'userManagement', moduleType: 'core' },
+          (err, count = 0) => err ? reject(err) : resolve(count)
+        );
+      })
+    ]);
 
-    // User existiert noch nicht, zeige register.html
-    if (userCount === 0) {
+    if (installVal !== 'true' || userCount === 0) {
       return res.redirect('/install');
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Admin route now checks installation status and redirects to `/install`
+  when no users exist or `FIRST_INSTALL_DONE` is not set.
 - POST /install now checks installation status to prevent creating
 - Automatically recreates `cms_settings` table if missing to avoid SQLite errors during first-time setup.
   additional admin users after setup.


### PR DESCRIPTION
## Summary
- check install status in `/admin/home` before showing login
- document admin route redirect logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e8c1e7ba483289595d242c09e3bf2