### PR TITLE
Fix first install redirect loop

### DIFF
--- a/BlogposterCMS/app.js
+++ b/BlogposterCMS/app.js
@@ -207,7 +207,7 @@ function getModuleTokenForDbManager() {
       })
     ]);
 
-    return installVal !== 'true' || userCount === 0;
+    return installVal !== 'true' && userCount === 0;
   }
 
   // Set up paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed infinite redirect loop between `/install` and `/login` when
+  `FIRST_INSTALL_DONE` wasn't set but user accounts existed.
 - `/admin` now verifies installation and user count before redirecting,
   ensuring first-time setups reach `/install` and all subsequent access
   goes to `/login`.


### PR DESCRIPTION
## Summary
- avoid redirect loop by requiring first install only when no users exist
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e9a6e6d8c83289f9d71f9d40f3963