### PR TITLE
Fix login crash before installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed crash when hitting `/admin` or `/login` during setup. The routes now
+  catch database errors and fall back to the installer instead of terminating.
 - Fixed infinite redirect loop between `/install` and `/login` when
   `FIRST_INSTALL_DONE` wasn't set but user accounts existed.
 - `/admin` now verifies installation and user count before redirecting,


### PR DESCRIPTION
## Summary
- handle DB errors in `needsInitialSetup`
- wrap `/login` in try/catch to avoid crashing
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eae4891a88328901e5b935f965295