### PR TITLE
Hide sidebar on admin home

### DIFF
--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -185,6 +185,15 @@ function ensureLayout(layout = {}, lane = 'public') {
     }
   }
 
+  const sidebarEl = document.getElementById('sidebar');
+  if (sidebarEl) {
+    if (layout.sidebar === 'empty-sidebar') {
+      sidebarEl.style.display = 'none';
+    } else {
+      sidebarEl.style.display = '';
+    }
+  }
+
   if (!document.getElementById('content')) {
     const content = document.createElement('section');
     content.id = 'content';
@@ -309,8 +318,10 @@ function ensureLayout(layout = {}, lane = 'public') {
     if (sidebarEl) {
       if (sidebarPartial !== 'empty-sidebar') {
         sidebarEl.innerHTML = await fetchPartial(sidebarPartial, 'sidebars');
+        sidebarEl.style.display = '';
       } else {
         sidebarEl.innerHTML = '';
+        sidebarEl.style.display = 'none';
       }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ El Psy Kongroo
 
 ## [Unreleased]
 - Fixed admin layout saving on SQLite by passing placeholder parameters as arrays.
+- Admin home screen now hides the sidebar completely.
 ## [0.5.1] – 2025-06-15
 - Startup no longer marks `FIRST_INSTALL_DONE` as true when no users exist, so
   `/install` remains accessible for creating the first admin account.


### PR DESCRIPTION
## Summary
- hide the sidebar when loading the admin home page
- document admin home sidebar removal in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc21dd13c8328920f64e9b1ef0d7c