### PR TITLE
Apply user-selected color to admin widgets

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_page-editor.scss
+++ b/BlogposterCMS/public/assets/scss/components/_page-editor.scss
@@ -51,7 +51,7 @@
 .user-edit-widget .field textarea:focus,
 .user-edit-widget select:focus {
   outline: none;
-  border-bottom: 2px solid #008080;
+  border-bottom: 2px solid var(--user-color);
 }
 
 .page-info-widget .field label,
@@ -87,7 +87,7 @@
 .user-edit-widget select:not([data-empty="true"]) + label {
   top: 0.25rem;
   font-size: 0.75rem;
-  color: #008080;
+  color: var(--user-color);
   background: none;
   font-weight: 500;
   letter-spacing: 0.02em;

--- a/BlogposterCMS/public/assets/scss/components/_top-header.scss
+++ b/BlogposterCMS/public/assets/scss/components/_top-header.scss
@@ -27,7 +27,7 @@
     cursor: pointer;
     transition: fill 0.2s, opacity 0.2s, transform 0.12s;
     &:hover {
-      fill: #FF00FF; // optional: oder var(--color-primary) für Branding
+      fill: var(--user-color);
       opacity: 1;
       transform: scale(1.12);
     }
@@ -71,7 +71,7 @@
 
       &:focus {
         outline: none;
-        border-bottom-color: #008080;
+        border-bottom-color: var(--user-color);
       }
     }
 

--- a/BlogposterCMS/public/assets/scss/pages/_pages.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_pages.scss
@@ -96,8 +96,8 @@
   transition: box-shadow 0.16s;
   border: 1px solid transparent;
   &:hover {
-    border: 1px solid #f0cfff;
-    box-shadow: 0 2px 16px rgba(208,0,175,0.08);
+    border: 1px solid var(--user-color);
+    box-shadow: 0 2px 16px rgba(0,0,0,0.08);
   }
 }
 
@@ -160,7 +160,7 @@
   opacity: 0.72;
   transition: fill 0.16s, opacity 0.14s, transform 0.14s;
   &:hover {
-    fill: #ff00ff;
+    fill: var(--user-color);
     opacity: 1;
     transform: scale(1.13);
   }
@@ -199,7 +199,7 @@
   margin-left: 2px;
   opacity: 0.8;
   &:hover {
-    fill: #FFA500;
+    fill: var(--user-color);
     opacity: 1;
   }
 }

--- a/BlogposterCMS/public/assets/scss/pages/_widgets.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_widgets.scss
@@ -43,14 +43,12 @@
 }
 
 .widget-tab.active {
-  border-bottom: 2px solid currentColor;
+  border-bottom: 2px solid var(--user-color);
+  color: var(--user-color);
   font-weight: bold;
 }
 
-.global-widget:hover {
-  box-shadow: 0 0 12px rgba(255, 0, 255, 0.5);
-}
-
+.global-widget:hover,
 .template-widget:hover {
-  box-shadow: 0 0 12px rgba(0, 128, 255, 0.4);
+  box-shadow: 0 0 0 2px var(--user-color);
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ El Psy Kongroo
 - Documented how to toggle render mode using the `RENDER_MODE` env var or runtime.local.js.
 - Fixed admin layout saving on SQLite by passing placeholder parameters as arrays.
 - Admin home screen now hides the sidebar completely.
+- Admin widgets subtly adopt the user's selected color across the dashboard for a personalized UI.
 
 ## [0.5.1] – 2025-06-15
 - Startup no longer marks `FIRST_INSTALL_DONE` as true when no users exist, so


### PR DESCRIPTION
## Summary
- use `--user-color` for icon hover and search focus
- update form styling to reference the user color variable
- highlight admin lists and icons with the user's color
- tweak widget styles to subtly reflect the active user's color
- document color usage in changelog

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_684fe0333de483288c831822fd7611d6