### PR TITLE
Fix userManagement mongo initialization

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
@@ -46,23 +46,54 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
         await createIndexWithRetry(db.collection('user_roles'), { user_id: 1, role_id: 1 }, { unique: true }).catch(() => {});
         await createIndexWithRetry(db.collection('permissions'), { permission_key: 1 }, { unique: true }).catch(() => {});
       
-        // Add some default fields if they're missing
-        await db.collection('users').updateMany({}, {
-          $set: {
-            email: '',
-            first_name: '',
-            last_name: '',
-            display_name: '',
-            phone: '',
-            company: '',
-            website: '',
-            avatar_url: '',
-            bio: '',
-            token_version: 0,
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString()
-          }
-        });
+        // Add some default fields if they're missing without overriding
+        // existing values. Avoid setting `email` to the same value on all
+        // documents as it conflicts with the unique index.
+        const usersCol = db.collection('users');
+        await usersCol.updateMany(
+          { first_name: { $exists: false } },
+          { $set: { first_name: '' } }
+        );
+        await usersCol.updateMany(
+          { last_name: { $exists: false } },
+          { $set: { last_name: '' } }
+        );
+        await usersCol.updateMany(
+          { display_name: { $exists: false } },
+          { $set: { display_name: '' } }
+        );
+        await usersCol.updateMany(
+          { phone: { $exists: false } },
+          { $set: { phone: '' } }
+        );
+        await usersCol.updateMany(
+          { company: { $exists: false } },
+          { $set: { company: '' } }
+        );
+        await usersCol.updateMany(
+          { website: { $exists: false } },
+          { $set: { website: '' } }
+        );
+        await usersCol.updateMany(
+          { avatar_url: { $exists: false } },
+          { $set: { avatar_url: '' } }
+        );
+        await usersCol.updateMany(
+          { bio: { $exists: false } },
+          { $set: { bio: '' } }
+        );
+        await usersCol.updateMany(
+          { token_version: { $exists: false } },
+          { $set: { token_version: 0 } }
+        );
+        await usersCol.updateMany(
+          { created_at: { $exists: false } },
+          { $set: { created_at: new Date().toISOString() } }
+        );
+        await usersCol.updateMany(
+          { updated_at: { $exists: false } },
+          { $set: { updated_at: new Date().toISOString() } }
+        );
       
         // Create index for "roles" and update to default fields
         await createIndexWithRetry(db.collection('roles'), { role_name: 1 }, { unique: true }).catch(() => {});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed duplicate key error on startup when the userManagement module
+  reinitializes with existing MongoDB users lacking email addresses.
 - Switching between client and server render modes now works by setting the
   `RENDER_MODE` environment variable or `features.renderMode` in
   `runtime.local.js`. The server strips `pageRenderer.js` automatically when


### PR DESCRIPTION
## Summary
- avoid duplicate key errors when userManagement runs more than once on MongoDB
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fe40711608328a5237519ad476d78