### PR TITLE
Add mandatory metadata for module uploads

### DIFF
--- a/BlogposterCMS/mother/modules/auth/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/auth/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "auth",
   "version": "0.5.0",
-  "description": "Core authentication services."
+  "description": "Core authentication services.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/databaseManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/databaseManager/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "databaseManager",
   "version": "0.5.0",
-  "description": "Gateway between modules and the database."
+  "description": "Gateway between modules and the database.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/dependencyLoader/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/dependencyLoader/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "dependencyLoader",
   "version": "0.5.0",
-  "description": "Whitelist manager for community module dependencies."
+  "description": "Whitelist manager for community module dependencies.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/importer/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/importer/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "importer",
   "version": "0.5.0",
-  "description": "Handles content importers from other platforms."
+  "description": "Handles content importers from other platforms.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/mediaManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/mediaManager/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "mediaManager",
   "version": "0.5.0",
-  "description": "Manages media library files and folders."
+  "description": "Manages media library files and folders.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/moduleLoader/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/moduleLoader/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "moduleLoader",
   "version": "0.5.0",
-  "description": "Loads optional modules with sandboxing."
+  "description": "Loads optional modules with sandboxing.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/moduleLoader/moduleInstallerService.js
+++ b/BlogposterCMS/mother/modules/moduleLoader/moduleInstallerService.js
@@ -41,6 +41,15 @@ async function installModuleFromZip(motherEmitter, jwt, uploadedZipBuffer, optio
       if (!moduleInfo.moduleName) {
         throw new Error('moduleInfo.json missing "moduleName" field.');
       }
+      if (!moduleInfo.version) {
+        throw new Error('moduleInfo.json missing "version" field.');
+      }
+      if (!moduleInfo.developer) {
+        throw new Error('moduleInfo.json missing "developer" field.');
+      }
+      if (!moduleInfo.description) {
+        throw new Error('moduleInfo.json missing "description" field.');
+      }
 
       // 3) Move to final /modules folder
       const finalModuleFolder = path.resolve(__dirname, `../../../modules/${moduleInfo.moduleName}`);

--- a/BlogposterCMS/mother/modules/notificationManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/notificationManager/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "notificationManager",
   "version": "0.5.0",
-  "description": "Sends notifications to integrations."
+  "description": "Sends notifications to integrations.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/pagesManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/pagesManager/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "pagesManager",
   "version": "0.5.0",
-  "description": "Manages pages and default content."
+  "description": "Manages pages and default content.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/plainSpace/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/plainSpace/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "plainSpace",
   "version": "0.5.0",
-  "description": "Seeds admin pages and widgets for builder."
+  "description": "Seeds admin pages and widgets for builder.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/serverManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/serverManager/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "serverManager",
   "version": "0.5.0",
-  "description": "Stores server location info."
+  "description": "Stores server location info.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/settingsManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/settingsManager/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "settingsManager",
   "version": "0.5.0",
-  "description": "Centralized CMS settings service."
+  "description": "Centralized CMS settings service.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/shareManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/shareManager/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "shareManager",
   "version": "0.5.0",
-  "description": "Creates secure share links for files."
+  "description": "Creates secure share links for files.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/themeManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/themeManager/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "themeManager",
   "version": "0.5.0",
-  "description": "Provides installed theme metadata."
+  "description": "Provides installed theme metadata.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/translationManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/translationManager/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "translationManager",
   "version": "0.5.0",
-  "description": "Stores translations for content strings."
+  "description": "Stores translations for content strings.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/unifiedSettings/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/unifiedSettings/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "unifiedSettings",
   "version": "0.5.0",
-  "description": "Registry of settings categories."
+  "description": "Registry of settings categories.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/userManagement/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/userManagement/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "userManagement",
   "version": "0.5.0",
-  "description": "CRUD for users and roles."
+  "description": "CRUD for users and roles.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/mother/modules/widgetManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/widgetManager/moduleInfo.json
@@ -1,5 +1,6 @@
 {
   "moduleName": "widgetManager",
   "version": "0.5.0",
-  "description": "Stores widgets for site and admin."
+  "description": "Stores widgets for site and admin.",
+  "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/public/assets/scss/pages/_modules.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_modules.scss
@@ -72,3 +72,32 @@
   cursor: pointer;
   font-size: 0.85rem;
 }
+
+.add-module-btn {
+  @extend .add-page-btn;
+}
+
+.module-upload-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.module-upload-box {
+  background: white;
+  padding: 20px;
+  border-radius: 6px;
+  text-align: center;
+  width: 300px;
+}
+
+.module-upload-box.dragover {
+  border: 2px dashed #888;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Added drag-and-drop module upload with ZIP validation. Modules require `moduleInfo.json` and `index.js`.
+- Module uploads now enforce `version`, `developer` and `description` fields in `moduleInfo.json`.
 - Switching between client and server render modes now works by setting the
   `RENDER_MODE` environment variable or `features.renderMode` in
   `runtime.local.js`. The server strips `pageRenderer.js` automatically when

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -61,7 +61,7 @@ The callback receives results only if the token has the `db.read` permission. Th
 1. Create a new folder under `modules/`.
 2. Add an `index.js` that exports an `initialize({ motherEmitter, jwt, isCore })` function.
 3. Inside `initialize`, register any meltdown event listeners your module needs.
-4. Include a `moduleInfo.json` file describing your module (name, version, permissions, etc.).
+4. Include a `moduleInfo.json` file describing your module. It must define `moduleName`, `version`, `developer` and `description`; other properties like permissions are optional.
 5. Restart the server. The Module Loader will automatically attempt to load the new module inside its sandbox.
 
 Modules should only interact with the rest of the CMS through meltdown events. Refer to existing core modules for practical examples.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -18,7 +18,7 @@ This mechanism ensures that even community modules cannot bypass security bounda
 
 1. Add a new folder under `modules/`.
 2. Place an `index.js` file inside it with an exported `initialize` function.
-3. Optionally include a `moduleInfo.json` file with metadata (name, version, permissions, description).
+3. Include a `moduleInfo.json` file with metadata. It must define `moduleName`, `version`, `developer` and `description` so the loader can detect updates and show author details. Additional fields like permissions are optional.
 4. Register any meltdown listeners within the `initialize` function. Use `motherEmitter.on('eventName', handler)` to react to events.
 5. Restart the CMS. The Module Loader will sandbox your module and activate it if no errors occur.
 

--- a/docs/modules/moduleLoader.md
+++ b/docs/modules/moduleLoader.md
@@ -16,4 +16,17 @@ Loads optional community modules from the top-level `modules/` directory. Each m
 - `listActiveGrapesModules`
 - `activateModuleInRegistry`
 
-Every module folder must export an `initialize` function and may include `moduleInfo.json` with metadata.
+Every module folder must export an `initialize` function and include `moduleInfo.json` with metadata.
+
+## Module Uploads
+
+Administrators can install additional modules through the admin interface. The upload button on the Modules page accepts a single ZIP archive. For security reasons the archive is extracted in a temporary directory and validated before activation.
+
+The ZIP must contain a folder with at least these files:
+
+1. **index.js** – entry point exporting an `initialize` function.
+2. **moduleInfo.json** – metadata describing the module. It must contain `moduleName`, `version`, `developer` and `description` so the system can track updates and authorship.
+
+Optional files such as `apiDefinition.json` or a `frontend/` folder may be included for modules that extend the builder. Any other resources will be placed in the module's directory.
+
+Uploaded modules run in a sandbox and lack network access unless explicitly allowed. Always review third‑party code before installing it.


### PR DESCRIPTION
## Summary
- require `version`, `developer` and `description` in uploaded moduleInfo
- update installer to validate these fields
- document mandatory metadata for modules
- record requirement in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fe2dcd03c8328800baec8014c82dd