### PR TITLE
Enhance user editor UI

### DIFF
--- a/BlogposterCMS/mother/modules/plainSpace/config/adminPages.js
+++ b/BlogposterCMS/mother/modules/plainSpace/config/adminPages.js
@@ -184,7 +184,11 @@ module.exports.ADMIN_PAGES = [
         sidebar: 'settings-sidebar',
         inheritsLayout: true
       },
-      widgets: ['userEdit']
+      widgets: ['userEdit'],
+      actionButton: {
+        icon: '/assets/icons/save.svg',
+        action: 'saveUserChanges'
+      }
     }
   },
   {

--- a/BlogposterCMS/public/assets/scss/components/_page-editor.scss
+++ b/BlogposterCMS/public/assets/scss/components/_page-editor.scss
@@ -94,6 +94,37 @@
   opacity: 0.94;
 }
 
+.user-field-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 1rem;
+}
+
+.color-choices {
+  display: flex;
+  gap: 6px;
+}
+
+.color-circle {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+.color-circle.active {
+  border-color: var(--user-color);
+}
+.color-circle.add-custom {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  border: 1px dashed #ccc;
+  color: #555;
+}
+
 #pe-save {
   display: inline-flex;
   align-items: center;

--- a/BlogposterCMS/tests/publicEvents.test.js
+++ b/BlogposterCMS/tests/publicEvents.test.js
@@ -64,7 +64,10 @@ async function testPublicRegister() {
   loadUserCrud(em);
   em.on('issueModuleToken', (p, cb) => cb(null, 'hight'));
   em.on('dbInsert', (p, cb) => { cb(null, [{ id: 1 }]); });
-  em.on('dbSelect', (p, cb) => { cb(null, [{ id: 10, role_name:'standard' }]); });
+  em.on('dbSelect', (p, cb) => {
+    if (p.table === 'users') return cb(null, []);
+    cb(null, [{ id: 10, role_name:'standard' }]);
+  });
   em.on('assignRoleToUser', (p, cb) => cb(null, true));
   const res = await new Promise((res, rej) => {
     em.emit('publicRegister', {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- User editor revamped with color picker, mandatory-field toggles and delete
+  button. Username and email uniqueness is validated before account creation.
 - Fixed duplicate key error on startup when the userManagement module
   reinitializes with existing MongoDB users lacking email addresses.
 - Switching between client and server render modes now works by setting the


### PR DESCRIPTION
## Summary
- validate username and email uniqueness before creating a user
- extend admin user editor with delete button, color picker and mandatory flags
- expose saveUserChanges via content header action button
- add styles for color picker and field rows
- adjust tests for new user creation check
- document the new editor behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fe8f7de808328a6cfe7140cd676fd