### PR TITLE
Fix floating toolbar for inline text editing

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
@@ -24,6 +24,14 @@
   border-bottom: 1px solid #eee;
 }
 
+.text-block-editor-toolbar.floating {
+  position: fixed;
+  top: 56px;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+}
+
 .text-block-editor {
   flex: 1;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Text editor toolbar now floats below the builder header and edits inline.
 - Added drag-and-drop module upload with ZIP validation. Modules require `moduleInfo.json` and `index.js`.
 - Module uploads now enforce `version`, `developer` and `description` fields in `moduleInfo.json`.
 - User editor revamped with color picker, mandatory-field toggles and delete


### PR DESCRIPTION
## Summary
- make text editor toolbar float below the builder header
- embed quill editor directly inside the widget
- update styles for floating toolbar
- document change in changelog

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684fef5536248328b1927c9ffa2dfb75