### PR TITLE
Fix floating toolbar in builder

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -7,6 +7,7 @@ const quillCssUrl = new URL('/assets/css/quill.snow.css', document.baseURI).href
 
 let toolbar = null;
 let quill = null;
+let qToolbar = null;
 let editorEl = null;
 let initPromise = null;
 let activeEl = null;
@@ -14,6 +15,12 @@ let changeHandler = null;
 let outsideHandler = null;
 let editingPlain = false;
 let autoHandler = null;
+const DEFAULT_TOOLBAR = [
+  [{ header: [1, 2, false] }],
+  ['bold', 'italic', 'underline', 'link'],
+  [{ list: 'ordered' }, { list: 'bullet' }],
+  ['clean']
+];
 
 export function sanitizeHtml(html) {
   const div = document.createElement('div');
@@ -103,6 +110,7 @@ function close() {
   }
   activeEl.innerHTML = html;
   toolbar.style.display = 'none';
+  if (qToolbar && toolbar.contains(qToolbar)) toolbar.removeChild(qToolbar);
   document.removeEventListener('pointerdown', outsideHandler, true);
   document.removeEventListener('mousedown', outsideHandler, true);
   const el = activeEl;
@@ -110,6 +118,7 @@ function close() {
   activeEl = null;
   editingPlain = false;
   editorEl = null;
+  qToolbar = null;
   quill = null;
   if (typeof cb === 'function') cb(el, html);
 }
@@ -132,7 +141,9 @@ export async function editElement(el, onSave) {
   el.appendChild(editorEl);
 
   const { initQuill } = await import(quillEditorUrl);
-  quill = initQuill(editorEl, { placeholder: '', modules: { toolbar } });
+  quill = initQuill(editorEl, { placeholder: '', modules: { toolbar: DEFAULT_TOOLBAR } });
+  qToolbar = quill.getModule('toolbar').container;
+  toolbar.appendChild(qToolbar);
   toolbar.style.display = 'block';
   quill.focus();
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed floating text editor toolbar missing default controls in builder mode.
 - Text editor toolbar now floats below the builder header and edits inline.
 - Added drag-and-drop module upload with ZIP validation. Modules require `moduleInfo.json` and `index.js`.
 - Module uploads now enforce `version`, `developer` and `description` fields in `moduleInfo.json`.


### PR DESCRIPTION
## Summary
- ensure Quill default toolbar controls show in builder mode
- document floating toolbar fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ff67fb7a88328aa60b98844a7d791