### PR TITLE
Add widget edit highlight

### DIFF
--- a/BlogposterCMS/public/assets/js/contentHeaderActions.js
+++ b/BlogposterCMS/public/assets/js/contentHeaderActions.js
@@ -28,6 +28,7 @@ export function initContentHeader() {
     if (!grid || typeof grid.setStatic !== 'function') return;
     editing = !editing;
     grid.setStatic(!editing);
+    document.body.classList.toggle('dashboard-edit-mode', editing);
     editToggle.src = editing ? '/assets/icons/check.svg' : '/assets/icons/edit.svg';
     editToggle.classList.add('spin');
     setTimeout(() => editToggle.classList.remove('spin'), 300);

--- a/BlogposterCMS/public/assets/scss/components/_content-area.scss
+++ b/BlogposterCMS/public/assets/scss/components/_content-area.scss
@@ -30,3 +30,8 @@
   min-height: 80px;
 }
 
+// Highlight widgets while the admin layout is editable
+body.dashboard-edit-mode .grid-stack-item {
+  border: 2px dashed var(--user-color);
+}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widgets show a dashed border in dashboard edit mode using the user's selected color.
 - Fixed floating text editor toolbar missing default controls in builder mode.
 - Text editor toolbar now floats below the builder header and edits inline.
 - Added drag-and-drop module upload with ZIP validation. Modules require `moduleInfo.json` and `index.js`.


### PR DESCRIPTION
## Summary
- highlight widgets with a user-colored dashed border while editing the dashboard
- toggle this highlight via the edit button
- document change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ff8e6ce20832885ff186eec40e752