### PR TITLE
Fix toolbar for custom text widgets

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -43,6 +43,18 @@ function findEditable(target) {
   return null;
 }
 
+function findEditableFromEvent(ev) {
+  if (typeof ev.composedPath === 'function') {
+    const path = ev.composedPath();
+    for (const node of path) {
+      if (node instanceof Element && isEditableElement(node) && node.closest('.grid-stack-item')) {
+        return node;
+      }
+    }
+  }
+  return findEditable(ev.target);
+}
+
 async function init() {
   if (initPromise) {
     await initPromise;
@@ -116,7 +128,7 @@ export function enableAutoEdit() {
   autoHandler = ev => {
     if (!document.body.classList.contains('builder-mode')) return;
     if (toolbar && toolbar.contains(ev.target)) return;
-    const el = findEditable(ev.target);
+    const el = findEditableFromEvent(ev);
     if (!el) return;
     ev.stopPropagation();
     editElement(el, el.__onSave);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed text block editor toolbar not opening after custom HTML edits by
+  scanning shadow DOM with composedPath.
 - Restored styling for the user editor with new classes for delete button
   and required field checkboxes.
 - Replaced Quill editor with a lightweight contenteditable toolbar (bold, italic, underline).


### PR DESCRIPTION
## Summary
- handle shadow DOM click paths when editing text
- note fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fffdecab0832883b9f98f31e230a6