### PR TITLE
Add responsive preview mode

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -6,6 +6,21 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   // Builder widgets load the active theme inside their shadow roots.
   // Inject the theme scoped to the builder grid so the preview matches
   // the active theme without altering the surrounding UI.
+  const DEFAULT_PORTS = [
+    { id: 'desktop', label: 'Desktop', class: 'preview-desktop' },
+    { id: 'tablet', label: 'Tablet', class: 'preview-tablet' },
+    { id: 'mobile', label: 'Mobile', class: 'preview-mobile' }
+  ];
+
+  const displayPorts = (Array.isArray(window.DISPLAY_PORTS) ? window.DISPLAY_PORTS : [])
+    .filter(p => p && p.id && p.label)
+    .map(p => ({
+      id: String(p.id),
+      label: String(p.label),
+      class: `preview-${String(p.id).replace(/[^a-z0-9_-]/gi, '')}`
+    }));
+  if (!displayPorts.length) displayPorts.push(...DEFAULT_PORTS);
+
   // Temporary patch: larger default widget height
   const DEFAULT_ROWS = 20; // around 100px with 5px grid cells
   const ICON_MAP = {
@@ -29,6 +44,40 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     savePageWidget: 'save',
     contentSummary: 'activity'
   };
+
+  let previewHeader;
+  let viewportSelect;
+
+  function showPreviewHeader() {
+    if (previewHeader) return;
+    previewHeader = document.createElement('div');
+    previewHeader.id = 'previewHeader';
+    previewHeader.className = 'preview-header';
+    viewportSelect = document.createElement('select');
+    displayPorts.forEach(p => {
+      const o = document.createElement('option');
+      o.value = p.class;
+      o.textContent = p.label;
+      viewportSelect.appendChild(o);
+    });
+    viewportSelect.addEventListener('change', () => {
+      document.body.classList.remove('preview-mobile', 'preview-tablet', 'preview-desktop');
+      const cls = viewportSelect.value;
+      if (cls) document.body.classList.add(cls);
+    });
+    previewHeader.appendChild(viewportSelect);
+    document.body.prepend(previewHeader);
+    viewportSelect.dispatchEvent(new Event('change'));
+  }
+
+  function hidePreviewHeader() {
+    if (previewHeader) {
+      previewHeader.remove();
+      previewHeader = null;
+      viewportSelect = null;
+    }
+    document.body.classList.remove('preview-mobile', 'preview-tablet', 'preview-desktop');
+  }
 
   function scopeThemeCss(css, rootPrefix, contentPrefix) {
     return css.replace(/(^|\})([^@{}]+)\{/g, (m, brace, selectors) => {
@@ -978,6 +1027,11 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     } else {
       const icon = active ? 'eye-off' : 'eye';
       previewBtn.innerHTML = `<img src="/assets/icons/${icon}.svg" alt="Preview" />`;
+    }
+    if (active) {
+      showPreviewHeader();
+    } else {
+      hidePreviewHeader();
     }
   });
 

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -307,6 +307,43 @@ body.preview-mode #builderGrid {
   pointer-events: none;
 }
 
+body.preview-mode #content {
+  margin-left: 0;
+}
+
+.preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: var(--color-white);
+  border-bottom: 1px solid #eee;
+  padding: 6px 12px;
+  position: sticky;
+  top: 0;
+  z-index: 60;
+}
+
+body.preview-mobile {
+  --preview-width: 400px;
+}
+
+body.preview-tablet {
+  --preview-width: 800px;
+}
+
+body.preview-desktop {
+  --preview-width: 1200px;
+}
+
+body.preview-mobile #content,
+body.preview-tablet #content,
+body.preview-desktop #content {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: var(--preview-width);
+}
+
 .grid-stack-item[gs-locked="true"] > .ui-resizable-handle {
   display: none;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Preview mode now locks widgets and expands the builder. A new preview header
+  lets you switch between desktop, tablet and mobile display ports.
 - Heading widget now uses the global text editor toolbar and retains content when opening the code editor.
 - Text block widget reports initial HTML to the builder and is always recognized as editable.
 - Fixed text block editor toolbar not opening after custom HTML edits by


### PR DESCRIPTION
## Summary
- enable real preview mode with viewport switcher in builder
- expand builder area in preview mode
- allow mobile/tablet/desktop preview widths
- document the new preview header in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685012aef89883288484075f1f69064f