### PR TITLE
Temporary lock during text edit

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -96,6 +96,10 @@ async function init() {
 
 function close() {
   if (!activeEl) return;
+  const widget = activeEl.closest('.grid-stack-item');
+  if (widget) {
+    document.dispatchEvent(new CustomEvent('textEditStop', { detail: { widget } }));
+  }
   activeEl.removeAttribute('contenteditable');
   let html = editingPlain ? activeEl.textContent : activeEl.innerHTML;
   html = sanitizeHtml(html.trim());
@@ -119,6 +123,10 @@ export async function editElement(el, onSave) {
   if (activeEl === el) return;
   if (activeEl) close();
   activeEl = el;
+  const startWidget = el.closest('.grid-stack-item');
+  if (startWidget) {
+    document.dispatchEvent(new CustomEvent('textEditStart', { detail: { widget: startWidget } }));
+  }
   activeEl.__onSave = onSave;
 
   editingPlain = !/<[a-z][\s\S]*>/i.test(el.innerHTML.trim());

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -527,6 +527,21 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   // Enable floating mode for easier widget placement in the builder
   const grid = initCanvasGrid({ float: true, cellHeight: 5, columnWidth: 5, column: 64 }, gridEl);
 
+  document.addEventListener('textEditStart', e => {
+    const widget = e.detail?.widget;
+    if (!widget) return;
+    if (widget.getAttribute('gs-locked') === 'true') return;
+    grid.update(widget, { locked: true, noMove: true, noResize: true });
+    widget.dataset.tempLock = 'true';
+  });
+
+  document.addEventListener('textEditStop', e => {
+    const widget = e.detail?.widget;
+    if (!widget || widget.dataset.tempLock !== 'true') return;
+    grid.update(widget, { locked: false, noMove: false, noResize: false });
+    widget.removeAttribute('data-temp-lock');
+  });
+
   document.addEventListener('click', e => {
     if (!activeWidgetEl) return;
     if (e.target.closest('.grid-stack-item') === activeWidgetEl ||

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widgets temporarily lock while editing text in the builder, enabling text selection.
 - Heading widget now uses the global text editor toolbar and retains content when opening the code editor.
 - Text block widget reports initial HTML to the builder and is always recognized as editable.
 - Fixed text block editor toolbar not opening after custom HTML edits by


### PR DESCRIPTION
## Summary
- lock grid items while editing text elements
- unlock grid items when text editing ends
- note temporary widget locking in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685014df06d48328a6402e3651371dbd