### PR TITLE
Hide gridstack handles in builder

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -272,6 +272,11 @@
   border-color: var(--user-color);
 }
 
+// Hide GridStack resize handles when using the bounding box
+.builder-mode .grid-stack-item > .ui-resizable-handle {
+  display: none;
+}
+
 
 body.builder-mode #content {
   margin-left: 96px;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- GridStack resize handles are hidden in the builder; the transformable bounding box now manages resizing.
 - Added login settings link in the sidebar and redesigned login strategies widget with toggle and edit icons.
 - Widgets temporarily lock while editing text in the builder, enabling text selection.
 - Preview mode now locks widgets and expands the builder. A new preview header


### PR DESCRIPTION
## Summary
- hide gridstack resize handles in builder mode
- document the change in the changelog

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_6850184739748328acc7dc0d2460f6c8