### PR TITLE
Fix ui_color installer error

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/mongoPlaceholders.js
@@ -63,6 +63,10 @@ async function handleBuiltInPlaceholderMongo(db, operation, params) {
           { $set: { display_name: '' } }
         );
         await usersCol.updateMany(
+          { ui_color: { $exists: false } },
+          { $set: { ui_color: '' } }
+        );
+        await usersCol.updateMany(
           { phone: { $exists: false } },
           { $set: { phone: '' } }
         );

--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/postgresPlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/postgresPlaceholders.js
@@ -25,6 +25,7 @@ switch (operation) {
             first_name     VARCHAR(255),
             last_name      VARCHAR(255),
             display_name   VARCHAR(255),
+            ui_color       VARCHAR(16),
             phone          VARCHAR(50),
             company        VARCHAR(255),
             website        VARCHAR(255),

--- a/BlogposterCMS/mother/modules/databaseManager/placeholders/sqlitePlaceholders.js
+++ b/BlogposterCMS/mother/modules/databaseManager/placeholders/sqlitePlaceholders.js
@@ -35,6 +35,7 @@ async function handleBuiltInPlaceholderSqlite(db, operation, params) {
           first_name    TEXT,
           last_name     TEXT,
           display_name  TEXT,
+          ui_color     TEXT,
           phone         TEXT,
           company       TEXT,
           website       TEXT,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ El Psy Kongroo
 - Preview mode now locks widgets and expands the builder. A new preview header
   lets you switch between desktop, tablet and mobile display ports.
 - Heading widget now uses the global text editor toolbar and retains content when opening the code editor.
+- User Management tables now include `ui_color` by default and migrations add
+  the column if missing, preventing installer failures on SQLite.
 - Text block widget reports initial HTML to the builder and is always recognized as editable.
 - Fixed text block editor toolbar not opening after custom HTML edits by
   scanning shadow DOM with composedPath.


### PR DESCRIPTION
## Summary
- add `ui_color` column to the default userManagement schema for all DB types
- default Mongo users now also initialize `ui_color`
- note fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68503b35a010832883f2c50d4491d4a1