### PR TITLE
Fix fonts page seeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed seeding for the Fonts page so the Font Providers widget is available on first run.
 - Bounding box respects widget lock state when editing text, preventing accidental resize.
 - Resizing widgets via the bounding box now adjusts their grid position when using the left or top handles.
 - Added Fonts Manager core module with pluggable providers and admin page.


### PR DESCRIPTION
## Summary
- seed default layout for admin pages during creation
- add entry to changelog

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_68503c6d722c8328b7a8160b429320e6