### PR TITLE
Fix Postgres engine loading on SQLite

### DIFF
--- a/BlogposterCMS/mother/modules/databaseManager/engines/engineFactory.js
+++ b/BlogposterCMS/mother/modules/databaseManager/engines/engineFactory.js
@@ -2,15 +2,12 @@
  * mother/modules/databaseManager/engines/engineFactory.js
  */
 const { getDbType } = require('../helpers/dbTypeHelpers');
-const postgresEngine = require('./postgresEngine');
-const mongoEngine = require('./mongoEngine');
-const sqliteEngine = require('./sqliteEngine');
 
 function getEngine() {
   const type = getDbType();
-  if (type === 'postgres') return postgresEngine;
-  if (type === 'mongodb') return mongoEngine;
-  if (type === 'sqlite') return sqliteEngine;
+  if (type === 'postgres') return require('./postgresEngine');
+  if (type === 'mongodb') return require('./mongoEngine');
+  if (type === 'sqlite') return require('./sqliteEngine');
   throw new Error(`[engineFactory] Unknown DB type=${type}`);
 }
 

--- a/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/createDatabaseEvent.js
+++ b/BlogposterCMS/mother/modules/databaseManager/meltdownBridging/createDatabaseEvent.js
@@ -4,11 +4,7 @@
  * meltdown => "createDatabase"
  */
 const { getEngine } = require('../engines/engineFactory');
-const { moduleHasOwnDb } = require('../helpers/dbTypeHelpers');
-const { createOrFixSchemaInMainDb } = require('../engines/postgresEngine');
-const { createMongoDatabase } = require('../engines/mongoEngine');
-const { createOrFixSqliteDatabaseForModule } = require('../engines/sqliteEngine');
-const { getDbType } = require('../helpers/dbTypeHelpers');
+const { moduleHasOwnDb, getDbType } = require('../helpers/dbTypeHelpers');
 const { onceCallback } = require('../../../emitters/motherEmitter');
 
 // NEW: Notification Emitter for typed notifications
@@ -50,7 +46,7 @@ function registerCreateDatabaseEvent(motherEmitter) {
           callback(null, { success: true, type: 'ownDb' });
         } else {
           // create or fix a shared schema in main DB
-          await createOrFixSchemaInMainDb(moduleName);
+          await engine.createOrFixSchemaInMainDb(moduleName);
           notificationEmitter.notify({
             moduleName: 'databaseManager',
             notificationType: 'info',
@@ -60,7 +56,7 @@ function registerCreateDatabaseEvent(motherEmitter) {
           callback(null, { success: true, type: 'sharedSchema' });
         }
       } else if (dbType === 'mongodb') {
-        await createMongoDatabase(moduleName);
+        await engine.createMongoDatabase(moduleName);
         notificationEmitter.notify({
           moduleName: 'databaseManager',
           notificationType: 'info',
@@ -69,7 +65,7 @@ function registerCreateDatabaseEvent(motherEmitter) {
         });
         callback(null, { success: true, type: 'mongodb' });
       } else if (dbType === 'sqlite') {
-        await createOrFixSqliteDatabaseForModule(moduleName, isOwnDb);
+        await engine.createOrFixSqliteDatabaseForModule(moduleName, isOwnDb);
         notificationEmitter.notify({
           moduleName: 'databaseManager',
           notificationType: 'info',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed crash on startup when using SQLite caused by loading the Postgres
+  engine unconditionally.
 - Fixed seeding for the Fonts page so the Font Providers widget is available on first run.
 - Bounding box respects widget lock state when editing text, preventing accidental resize.
 - Resizing widgets via the bounding box now adjusts their grid position when using the left or top handles.


### PR DESCRIPTION
## Summary
- load database engines dynamically
- avoid requiring Postgres engine when using SQLite
- document fix in CHANGELOG

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_685042d3590c8328bd99d14cb572452e