### PR TITLE
Add font size control to builder text editor toolbar

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -79,7 +79,15 @@ async function init() {
       '<button type="button" class="tb-btn" data-cmd="underline">' + window.featherIcon('underline') + '</button>',
       '<select class="heading-select" style="display:none">' +
         ['h1','h2','h3','h4','h5','h6'].map(h => `<option value="${h}">${h.toUpperCase()}</option>`).join('') +
-      '</select>'
+      '</select>',
+      '<div class="font-size-control">' +
+        '<button type="button" class="tb-btn fs-dec">-</button>' +
+        '<input type="number" class="fs-input" value="16" min="8" />' +
+        '<button type="button" class="tb-btn fs-inc">+</button>' +
+        '<div class="fs-dropdown"><span class="fs-current">16</span><div class="fs-options">' +
+          [12,14,16,18,24,36].map(s => `<span data-size="${s}">${s}</span>`).join('') +
+        '</div></div>' +
+      '</div>'
     ].join('');
     toolbar.addEventListener('click', ev => {
       const btn = ev.target.closest('button[data-cmd]');
@@ -90,6 +98,34 @@ async function init() {
       activeEl?.focus();
     });
     document.body.appendChild(toolbar);
+
+    const fsInput = toolbar.querySelector('.fs-input');
+    const fsCurrent = toolbar.querySelector('.fs-current');
+    const fsDropdown = toolbar.querySelector('.fs-dropdown');
+    const fsOptions = toolbar.querySelector('.fs-options');
+    const applySize = size => {
+      const val = parseInt(size, 10);
+      if (!val) return;
+      fsInput.value = val;
+      fsCurrent.textContent = val;
+      if (activeEl) activeEl.style.fontSize = val + 'px';
+    };
+    toolbar.querySelector('.fs-inc').addEventListener('click', () => {
+      applySize((parseInt(fsInput.value, 10) || 16) + 1);
+    });
+    toolbar.querySelector('.fs-dec').addEventListener('click', () => {
+      applySize((parseInt(fsInput.value, 10) || 16) - 1);
+    });
+    fsInput.addEventListener('change', () => applySize(fsInput.value));
+    fsCurrent.addEventListener('click', () => {
+      fsDropdown.classList.toggle('open');
+    });
+    fsOptions.addEventListener('click', ev => {
+      const opt = ev.target.closest('span[data-size]');
+      if (!opt) return;
+      applySize(opt.dataset.size);
+      fsDropdown.classList.remove('open');
+    });
   })();
   await initPromise;
 }

--- a/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
@@ -30,6 +30,49 @@
   .heading-select {
     margin-left: 8px;
   }
+  .font-size-control {
+    margin-left: 8px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    position: relative;
+
+    .fs-input {
+      width: 40px;
+      text-align: center;
+    }
+
+    .fs-dropdown {
+      position: relative;
+      cursor: pointer;
+
+      .fs-options {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        background: var(--color-white);
+        box-shadow: var(--shadow-default);
+        z-index: 2000;
+        padding: 4px 0;
+        white-space: nowrap;
+
+        span {
+          display: block;
+          padding: 4px 8px;
+          cursor: pointer;
+
+          &:hover {
+            background: var(--color-primary-light);
+          }
+        }
+      }
+
+      &.open .fs-options {
+        display: block;
+      }
+    }
+  }
 }
 
 .text-block-editor-toolbar.floating {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Added font size control to the text editor toolbar for customizing widget text sizes.
 - Form inputs in widgets now select and lock the widget when focused, so
   the action menu appears during text entry.
 - PlainSpace initialization now registers layout events and creates tables


### PR DESCRIPTION
## Summary
- add font size UI in text editor toolbar with increase/decrease buttons and preset dropdown
- style new toolbar control via SCSS
- document feature in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68504ece32f4832889335af4d52b5655