### PR TITLE
Update fonts widget design

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/fontsListWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/fontsListWidget.js
@@ -29,7 +29,7 @@ export async function render(el) {
     if (!providers.length) {
       const empty = document.createElement('div');
       empty.className = 'empty-state';
-      empty.textContent = 'No providers found.';
+      empty.textContent = 'No font providers configured. Add one to use custom fonts.';
       list.appendChild(empty);
     } else {
       providers.forEach(p => {
@@ -45,10 +45,11 @@ export async function render(el) {
         const actions = document.createElement('span');
         actions.className = 'font-actions';
 
-        const toggleBtn = document.createElement('button');
-        toggleBtn.className = 'font-toggle-btn';
-        toggleBtn.textContent = p.isEnabled ? 'Deactivate' : 'Activate';
-        toggleBtn.addEventListener('click', async () => {
+        const toggleIcon = document.createElement('span');
+        toggleIcon.className = 'icon font-toggle-icon';
+        toggleIcon.innerHTML = window.featherIcon(p.isEnabled ? 'toggle-right' : 'toggle-left');
+        toggleIcon.title = p.isEnabled ? 'Disable' : 'Enable';
+        toggleIcon.addEventListener('click', async () => {
           try {
             await meltdownEmit('setFontProviderEnabled', {
               jwt,
@@ -58,13 +59,14 @@ export async function render(el) {
               enabled: !p.isEnabled
             });
             p.isEnabled = !p.isEnabled;
-            toggleBtn.textContent = p.isEnabled ? 'Deactivate' : 'Activate';
+            toggleIcon.innerHTML = window.featherIcon(p.isEnabled ? 'toggle-right' : 'toggle-left');
+            toggleIcon.title = p.isEnabled ? 'Disable' : 'Enable';
           } catch (err) {
             alert('Error: ' + err.message);
           }
         });
 
-        actions.appendChild(toggleBtn);
+        actions.appendChild(toggleIcon);
         nameRow.appendChild(nameEl);
         nameRow.appendChild(actions);
 

--- a/BlogposterCMS/public/assets/scss/pages/_fonts.scss
+++ b/BlogposterCMS/public/assets/scss/pages/_fonts.scss
@@ -42,11 +42,6 @@
   color: #555;
 }
 
-.font-toggle-btn {
-  background: #f6f6f6;
-  border: none;
-  border-radius: 5px;
-  padding: 2px 8px;
+.font-toggle-icon {
   cursor: pointer;
-  font-size: 0.85rem;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ El Psy Kongroo
   promises during setup.
 - Fixed seeding for the Fonts page so the Font Providers widget is available on first run.
 - Bounding box respects widget lock state when editing text, preventing accidental resize.
+- Fonts widget now shows toggle icons and clearer empty-state text to match other settings widgets.
 - Resizing widgets via the bounding box now adjusts their grid position when using the left or top handles.
 - Widget selection is restored after editing text so the action toolbar and bounding box reappear automatically.
 - Added Fonts Manager core module with pluggable providers and admin page.


### PR DESCRIPTION
## Summary
- update Fonts widget to use icons like other Settings widgets
- improve empty state message
- update SCSS styles
- document fonts widget update in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68504c95b1e083289af544d07e0b46dd