### PR TITLE
Prevent module meltdown on expired tokens

### DIFF
--- a/BlogposterCMS/app.js
+++ b/BlogposterCMS/app.js
@@ -166,7 +166,8 @@ function getModuleTokenForDbManager() {
       motherEmitter.emit(
         'validateToken',
         {
-          jwt: token,
+          skipJWT: true,
+          authModuleSecret: AUTH_MODULE_SECRET,
           moduleName: 'auth',
           moduleType: 'core',
           tokenToValidate: token

--- a/BlogposterCMS/mother/emitters/motherEmitter.js
+++ b/BlogposterCMS/mother/emitters/motherEmitter.js
@@ -37,7 +37,8 @@ const PUBLIC_EVENTS = [
 const ALLOWED_SKIPJWT_EVENTS = [
   'issueUserToken',
   'issueModuleToken',
-  'registerLoginStrategy'
+  'registerLoginStrategy',
+  'validateToken'
 ];
 
 /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 El Psy Kongroo
 
+## [Unreleased]
+- Admin token validation no longer deactivates core modules when the session token has expired.
+
 ## [0.5.3] – 2025-06-17
 - Font size selector in the text editor now shows preset sizes below the input while typing and aligns with other toolbar controls.
 


### PR DESCRIPTION
## Summary
- allow `validateToken` with skipJWT
- use skipJWT when checking admin tokens
- document fix

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68511c6efa688328944f186fb62a0e57