### PR TITLE
Fix builder action bar reposition on move

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -601,6 +601,18 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   await applyBuilderTheme();
   // Enable floating mode for easier widget placement in the builder
   const grid = initCanvasGrid({ float: true, cellHeight: 5, columnWidth: 5, column: 64 }, gridEl);
+  grid.grid.on("dragstart", () => {
+    actionBar.style.display = "none";
+  });
+  grid.grid.on("resizestart", () => {
+    actionBar.style.display = "none";
+  });
+  grid.grid.on("dragstop", (_, el) => {
+    if (activeWidgetEl) selectWidget(activeWidgetEl);
+  });
+  grid.grid.on("resizestop", (_, el) => {
+    if (activeWidgetEl) selectWidget(activeWidgetEl);
+  });
 
   document.addEventListener('textEditStart', e => {
     const widget = e.detail?.widget;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ El Psy Kongroo
 
 ## [Unreleased]
 - Font size selector in the text editor now shows preset sizes below the input while typing and aligns with other toolbar controls.
+- Action bar now hides during widget drag or resize and reappears at the new position.
 
 ## [0.5.2] – 2025-06-16
 - Widgets auto-lock when editing text fields and unlock as soon as focus leaves


### PR DESCRIPTION
## Summary
- hide and show the builder action bar when widgets are dragged or resized so it reappears at the correct position
- document the action bar behaviour change

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_685246a42bd483288f91fe2e31ac4100