### PR TITLE
Fix font size selection in text editor

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -119,10 +119,12 @@ async function init() {
         activeEl.contains(sel.focusNode)
       ) {
         try {
-          const range = sel.getRangeAt(0);
+          const range = sel.getRangeAt(0).cloneRange();
           const span = document.createElement('span');
           span.style.fontSize = val + 'px';
-          range.surroundContents(span);
+          const frag = range.extractContents();
+          span.appendChild(frag);
+          range.insertNode(span);
           sel.removeAllRanges();
           const newRange = document.createRange();
           newRange.selectNodeContents(span);
@@ -133,6 +135,9 @@ async function init() {
         }
       } else {
         activeEl.style.fontSize = val + 'px';
+        activeEl
+          .querySelectorAll('[style*="font-size"]')
+          .forEach(el => (el.style.fontSize = val + 'px'));
       }
       editingPlain = false;
       activeEl.focus();
@@ -181,6 +186,11 @@ function close() {
   activeEl.removeAttribute('contenteditable');
   let html = editingPlain ? activeEl.textContent : activeEl.innerHTML;
   html = sanitizeHtml(html.trim());
+  if (editingPlain) {
+    activeEl.textContent = html;
+  } else {
+    activeEl.innerHTML = html;
+  }
   toolbar.style.display = 'none';
   const headingSelect = toolbar.querySelector('.heading-select');
   if (headingSelect) {

--- a/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
@@ -21,6 +21,8 @@
 .text-block-editor-toolbar {
   background: var(--color-white);
   border-bottom: 1px solid #eee;
+  display: flex;
+  align-items: center;
   .tb-btn {
     background: none;
     border: none;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Increasing font size without a selection now affects the entire widget.
 - Font size selector in the text editor now shows preset sizes below the input while typing and aligns with other toolbar controls.
+- Font size tool aligns with other buttons and updates selected text directly in widgets.
 
 ## [0.5.2] – 2025-06-16
 - Widgets auto-lock when editing text fields and unlock as soon as focus leaves


### PR DESCRIPTION
## Summary
- align text editor toolbar using flexbox
- allow font size changes on selected text
- sanitize and persist updated HTML
- default font-size changes to entire widget if nothing selected
- update changelog

## Testing
- `npx jest`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_685247426c408328b2e326658c7eda3f