### PR TITLE
Add Google Fonts provider

### DIFF
--- a/BlogposterCMS/mother/modules/fontsManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/fontsManager/moduleInfo.json
@@ -1,6 +1,6 @@
 {
   "moduleName": "fontsManager",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Manages font provider strategies.",
   "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/public/admin.html
+++ b/BlogposterCMS/public/admin.html
@@ -30,6 +30,7 @@
 
   <!-- 2) Meltdown-Emitter wrapper (ES-module, needs the global above) -->
   <script type="module" src="/assets/js/meltdownEmitter.js"></script>
+  <script type="module" src="/assets/js/fontsLoader.js"></script>
   <script src="/assets/js/openExplorer.js"></script>
 
   <!-- Quill rich text editor -->

--- a/BlogposterCMS/public/assets/js/fontsLoader.js
+++ b/BlogposterCMS/public/assets/js/fontsLoader.js
@@ -1,0 +1,33 @@
+(async () => {
+  if (typeof window.meltdownEmit !== 'function') return;
+  try {
+    const jwt = await window.meltdownEmit('issuePublicToken', {
+      purpose: 'fonts',
+      moduleName: 'auth'
+    });
+    let providers = await window.meltdownEmit('listFontProviders', {
+      jwt,
+      moduleName: 'fontsManager',
+      moduleType: 'core'
+    });
+    providers = Array.isArray(providers) ? providers : (providers?.data ?? []);
+    const google = providers.find(p => p.name === 'googleFonts');
+    if (google && google.isEnabled) {
+      const urls = [
+        'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600&display=swap',
+        'https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600&display=swap',
+        'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600&display=swap',
+        'https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600&display=swap',
+        'https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600&display=swap'
+      ];
+      urls.forEach(href => {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = href;
+        document.head.appendChild(link);
+      });
+    }
+  } catch (err) {
+    console.error('[fontsLoader] Failed to load fonts', err);
+  }
+})();

--- a/BlogposterCMS/public/assets/scss/_fonts.scss
+++ b/BlogposterCMS/public/assets/scss/_fonts.scss
@@ -36,18 +36,4 @@
    Google Fonts imports (zentral)
    ================================ */
 
-/* OpenAI Sans ähnliche Fonts */
-
-/* Manrope (aktiviert) */
-@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600&display=swap');
-
-/* Work Sans (deaktiviert) */
-@import url('https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600&display=swap'); 
-
-/* Plus Jakarta Sans (deaktiviert) */
-@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600&display=swap'); 
-
-/* Sora (deaktiviert) */
-@import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600&display=swap');
-
-@import url('https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600&display=swap')
+/* Google fonts are loaded dynamically when the provider is enabled. */

--- a/BlogposterCMS/public/index.html
+++ b/BlogposterCMS/public/index.html
@@ -20,6 +20,7 @@
   <script src="/assets/js/gridstack.all.js"></script>
   <!-- miniEmitter: your single Meltdown API tunnel -->
   <script src="/assets/js/meltdownEmitter.js"></script>
+  <script type="module" src="/assets/js/fontsLoader.js"></script>
   <!-- global media explorer -->
   <script src="/assets/js/openExplorer.js"></script>
   <!-- Your pageRenderer, which now just calls miniEmitter(...) -->

--- a/BlogposterCMS/public/install.html
+++ b/BlogposterCMS/public/install.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <title>Install BlogposterCMS</title>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600&display=swap">
   <link rel="stylesheet" href="/assets/css/site.css" />
   <meta name="csrf-token" content="{{CSRF_TOKEN}}">
 </head>
@@ -38,6 +37,8 @@
       </form>
     </div>
   </div>
+  <script type="module" src="/assets/js/meltdownEmitter.js"></script>
+  <script type="module" src="/assets/js/fontsLoader.js"></script>
   <script src="/assets/js/install.js"></script>
 </body>
 </html>

--- a/BlogposterCMS/public/login.html
+++ b/BlogposterCMS/public/login.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <title>Admin Panel</title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600&display=swap">
   <link rel="stylesheet" href="/assets/css/site.css" />
   <meta name="csrf-token" content="{{CSRF_TOKEN}}">
 </head>
@@ -33,6 +32,7 @@
   </div>
 
   <script type="module" src="/assets/js/meltdownEmitter.js"></script>
+  <script type="module" src="/assets/js/fontsLoader.js"></script>
   <script type="module" src="/assets/js/firstInstallCheck.js"></script>
   <script src="/assets/js/login.js"></script>
   <script type="module" src="/assets/js/loginStrategiesPublic.js"></script>

--- a/BlogposterCMS/public/register.html
+++ b/BlogposterCMS/public/register.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <title>First-Time Registration</title>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600&display=swap">
   <link rel="stylesheet" href="/assets/css/site.css" />
 </head>
 <body>
@@ -30,6 +29,8 @@
     </div>
   </div><!-- .app-scope -->
 
+  <script type="module" src="/assets/js/meltdownEmitter.js"></script>
+  <script type="module" src="/assets/js/fontsLoader.js"></script>
   <script src="/assets/js/register.js"></script>
 </body>
 </html>

--- a/BlogposterCMS/webpack.config.js
+++ b/BlogposterCMS/webpack.config.js
@@ -19,7 +19,8 @@ module.exports = {
     tokenLoader: './public/assets/js/tokenLoader.js',
     topHeaderActions: './public/assets/js/topHeaderActions.js',
     openExplorer: './public/assets/js/openExplorer.js',
-    pageActions: './public/assets/js/pageActions.js'
+    pageActions: './public/assets/js/pageActions.js',
+    fontsLoader: './public/assets/js/fontsLoader.js'
   },
   output: {
     filename: '[name].js',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fonts Manager now loads Google Fonts dynamically and can be toggled from the admin Fonts page.
 - Font size selector in the text editor now shows preset sizes below the input while typing and aligns with other toolbar controls.
 
 ## [0.5.2] – 2025-06-16

--- a/docs/modules/fontsManager.md
+++ b/docs/modules/fontsManager.md
@@ -11,7 +11,10 @@ or disabling them via the admin settings.
 - Keeps a registry of available font providers.
 - Lets admins toggle providers on or off for privacy.
 - Additional providers can register themselves using the
-  `registerFontProvider` event.
+  `registerFontProvider` event. The built-in **Google Fonts** provider is
+  disabled by default for privacy. When enabled, the front-end dynamically loads
+  the fonts via `fontsLoader.js` so no external requests occur unless
+  explicitly allowed.
 
 ## Listened Events
 - `listFontProviders`


### PR DESCRIPTION
## Summary
- load Google fonts dynamically using new `fontsLoader.js`
- enable/disable fonts via Fonts Manager provider
- link loader script across HTML pages
- document new behaviour and bump fontsManager module version
- note toggleable provider in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685247c4571083289a934dd3d40686fd