### PR TITLE
Add universal color picker

### DIFF
--- a/BlogposterCMS/public/assets/js/colorPicker.js
+++ b/BlogposterCMS/public/assets/js/colorPicker.js
@@ -1,0 +1,73 @@
+export function createColorPicker(options = {}) {
+  const {
+    presetColors = [
+      '#FF0000', '#FF4040', '#FFC0CB', '#FF00FF', '#800080', '#8A2BE2',
+      '#00CED1', '#00FFFF', '#40E0D0', '#ADD8E6', '#4169E1', '#0047AB',
+      '#008000', '#7CFC00', '#BFFF00', '#FFFF00', '#FFDAB9', '#FFA500',
+      '#000000', '#A9A9A9', '#808080'
+    ],
+    userColors = [],
+    themeColors = [],
+    initialColor = presetColors[0],
+    onSelect = () => {}
+  } = options;
+
+  let selectedColor = initialColor;
+  const container = document.createElement('div');
+  container.className = 'color-picker';
+
+  function createSection(colors, label) {
+    if (!colors || !colors.length) return;
+    const wrapper = document.createElement('div');
+    const section = document.createElement('div');
+    section.className = 'color-section';
+    if (label) {
+      const lbl = document.createElement('span');
+      lbl.className = 'color-section-label';
+      lbl.textContent = label;
+      wrapper.appendChild(lbl);
+    }
+    colors.forEach(c => {
+      if (!c) return;
+      const circle = document.createElement('div');
+      circle.className = 'color-circle';
+      circle.style.backgroundColor = c;
+      if (c === selectedColor) circle.classList.add('active');
+      circle.addEventListener('click', () => {
+        selectedColor = c;
+        container.querySelectorAll('.color-circle').forEach(n => n.classList.remove('active'));
+        circle.classList.add('active');
+        onSelect(selectedColor);
+      });
+      section.appendChild(circle);
+    });
+    const addCustom = document.createElement('div');
+    addCustom.className = 'color-circle add-custom';
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.style.display = 'none';
+    addCustom.appendChild(colorInput);
+    addCustom.addEventListener('click', () => colorInput.click());
+    colorInput.addEventListener('input', () => {
+      selectedColor = colorInput.value;
+      container.querySelectorAll('.color-circle').forEach(n => n.classList.remove('active'));
+      addCustom.style.backgroundColor = selectedColor;
+      addCustom.classList.add('active');
+      onSelect(selectedColor);
+    });
+    section.appendChild(addCustom);
+    wrapper.appendChild(section);
+    container.appendChild(wrapper);
+  }
+
+  createSection(presetColors, 'Presets');
+  createSection(userColors, 'Your colors');
+  createSection(themeColors, 'Theme');
+
+  return {
+    el: container,
+    getColor() {
+      return selectedColor;
+    }
+  };
+}

--- a/BlogposterCMS/public/assets/plainspace/admin/userEditWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/userEditWidget.js
@@ -1,3 +1,5 @@
+import { createColorPicker } from '../../js/colorPicker.js';
+
 export async function render(el) {
   const meltdownEmit = window.meltdownEmit;
   const jwt = window.ADMIN_TOKEN;
@@ -76,34 +78,16 @@ export async function render(el) {
       if (f === 'bio') {
         input = document.createElement('textarea');
       } else if (f === 'ui_color') {
-        input = document.createElement('div');
-        input.className = 'color-choices';
-        colorChoices.forEach(c => {
-          const circle = document.createElement('div');
-          circle.className = 'color-circle';
-          circle.style.backgroundColor = c;
-          circle.addEventListener('click', () => {
-            selectedColor = c;
-            Array.from(input.children).forEach(n => n.classList.remove('active'));
-            circle.classList.add('active');
-          });
-          if (c === selectedColor) circle.classList.add('active');
-          input.appendChild(circle);
+        const themeColor = getComputedStyle(document.documentElement)
+          .getPropertyValue('--accent-color').trim();
+        const picker = createColorPicker({
+          presetColors: colorChoices,
+          userColors: user.ui_color ? [user.ui_color] : [],
+          themeColors: themeColor ? [themeColor] : [],
+          initialColor: selectedColor,
+          onSelect: c => { selectedColor = c; }
         });
-        const addCustom = document.createElement('div');
-        addCustom.className = 'color-circle add-custom';
-        const colorInput = document.createElement('input');
-        colorInput.type = 'color';
-        colorInput.style.display = 'none';
-        addCustom.appendChild(colorInput);
-        addCustom.addEventListener('click', () => colorInput.click());
-        colorInput.addEventListener('input', () => {
-          selectedColor = colorInput.value;
-          Array.from(input.children).forEach(n => n.classList.remove('active'));
-          addCustom.style.backgroundColor = selectedColor;
-          addCustom.classList.add('active');
-        });
-        input.appendChild(addCustom);
+        input = picker.el;
       } else {
         input = document.createElement('input');
         input.type = 'text';

--- a/BlogposterCMS/public/assets/scss/components/_color-picker.scss
+++ b/BlogposterCMS/public/assets/scss/components/_color-picker.scss
@@ -1,0 +1,39 @@
+.color-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  .color-section {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+  }
+
+  .color-circle {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    cursor: pointer;
+    border: 2px solid transparent;
+  }
+
+  .color-circle.active {
+    border-color: var(--user-color);
+  }
+
+  .color-circle.add-custom {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #fff;
+    border: 1px dashed #ccc;
+    color: #555;
+  }
+
+  .color-section-label {
+    margin-right: 4px;
+    font-size: 12px;
+    color: var(--color-text);
+  }
+}

--- a/BlogposterCMS/public/assets/scss/site.scss
+++ b/BlogposterCMS/public/assets/scss/site.scss
@@ -7,6 +7,7 @@
 @import 'global';
 @import 'components/buttons';
 @import 'components/forms';
+@import 'components/color-picker';
 @import 'cards';
 @import 'responsive';
 @import 'components/sidebar-bubble';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Added reusable color picker component that shows preset, user and theme colors.
 - Font size selector in the text editor now shows preset sizes below the input while typing and aligns with other toolbar controls.
 - Action bar now hides during widget drag or resize and reappears at the new position.
 


### PR DESCRIPTION
## Summary
- implement `colorPicker.js` as a reusable component
- add `_color-picker.scss` and import it in the main stylesheet
- use the new color picker in the user editor
- document the feature in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68524994338c8328a423a98ef5f31333