### PR TITLE
Hide Gridstack drag placeholder

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -311,6 +311,11 @@
   display: none;
 }
 
+// Hide GridStack drag placeholder to avoid showing an old position
+.builder-mode .grid-stack-placeholder {
+  display: none !important;
+}
+
 
 body.builder-mode #content {
   margin-left: 96px;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Dragging widgets no longer shows a ghost box at their old location in the builder.
 - Text color button now displays an underlined 'A' icon reflecting the selected color and opens the palette below the toolbar.
 - Color picker in user editor now floats above fields when opened.
 - Text editor toolbar now includes a floating color picker to change selected text or entire blocks.


### PR DESCRIPTION
## Summary
- hide GridStack drag placeholder in builder mode
- document the change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68525db6de9083289c4157adeba68983