### PR TITLE
Patch XSS risk in pageRenderer

### DIFF
--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -2,7 +2,7 @@
 
 import { fetchPartial } from '../plainspace/admin/fetchPartial.js';
 import { initBuilder } from '../plainspace/admin/builderRenderer.js';
-import { enableAutoEdit } from './globalTextEditor.js';
+import { enableAutoEdit, sanitizeHtml } from './globalTextEditor.js';
 
 // Default rows for admin widgets (~50px with 5px grid cells)
 // Temporary patch: double the default height for larger widgets
@@ -107,7 +107,7 @@ function renderWidget(wrapper, def, code = null, lane = 'public') {
       root.appendChild(customStyle);
     }
     if (code.html) {
-      container.innerHTML = code.html;
+      container.innerHTML = sanitizeHtml(code.html);
     }
     if (code.js) {
       try { executeJs(code.js, wrapper, root); } catch (e) { console.error('[Renderer] custom js error', e); }
@@ -267,9 +267,11 @@ function ensureLayout(layout = {}, lane = 'public') {
     // 4. LOAD HEADER PARTIALS
     if (slug !== 'builder') {
       if (topHeaderEl) {
-        topHeaderEl.innerHTML = await fetchPartial(
-          config.layout?.header || 'top-header',
-          'headers'
+        topHeaderEl.innerHTML = sanitizeHtml(
+          await fetchPartial(
+            config.layout?.header || 'top-header',
+            'headers'
+          )
         );
         document.dispatchEvent(new CustomEvent('top-header-loaded'));
       }
@@ -277,7 +279,9 @@ function ensureLayout(layout = {}, lane = 'public') {
           if (config.layout?.inheritsLayout === false && !config.layout?.topHeader) {
             mainHeaderEl.innerHTML = '';
           } else {
-            mainHeaderEl.innerHTML = await fetchPartial(config.layout?.mainHeader || 'main-header', 'headers');
+            mainHeaderEl.innerHTML = sanitizeHtml(
+              await fetchPartial(config.layout?.mainHeader || 'main-header', 'headers')
+            );
           }
           if (lane === 'admin' && page.title) {
             const t = mainHeaderEl.querySelector('.site-title');
@@ -286,9 +290,11 @@ function ensureLayout(layout = {}, lane = 'public') {
         }
       const contentHeaderEl = document.getElementById('content-header');
       if (contentHeaderEl) {
-        contentHeaderEl.innerHTML = await fetchPartial(
-          config.layout?.contentHeader || 'content-header',
-          'headers'
+        contentHeaderEl.innerHTML = sanitizeHtml(
+          await fetchPartial(
+            config.layout?.contentHeader || 'content-header',
+            'headers'
+          )
         );
         document.dispatchEvent(new CustomEvent('content-header-loaded'));
       }
@@ -298,7 +304,9 @@ function ensureLayout(layout = {}, lane = 'public') {
     if (slug === 'builder') {
       const builderSidebar = config.layout?.sidebar || 'sidebar-builder';
       if (sidebarEl) {
-        sidebarEl.innerHTML = await fetchPartial(builderSidebar, 'sidebars');
+        sidebarEl.innerHTML = sanitizeHtml(
+          await fetchPartial(builderSidebar, 'sidebars')
+        );
       }
 
       const urlParams = new URLSearchParams(window.location.search);
@@ -320,7 +328,9 @@ function ensureLayout(layout = {}, lane = 'public') {
 
     if (sidebarEl) {
       if (sidebarPartial !== 'empty-sidebar') {
-        sidebarEl.innerHTML = await fetchPartial(sidebarPartial, 'sidebars');
+        sidebarEl.innerHTML = sanitizeHtml(
+          await fetchPartial(sidebarPartial, 'sidebars')
+        );
         sidebarEl.style.display = '';
       } else {
         sidebarEl.innerHTML = '';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ El Psy Kongroo
 - Font size selector in the text editor now shows preset sizes below the input while typing and aligns with other toolbar controls.
 - Font size tool aligns with other buttons and updates selected text directly in widgets.
 - Admin token validation no longer deactivates core modules when the session token has expired.
+- Sanitized HTML fetched for layout partials and custom widgets to prevent DOM text from being interpreted as executable markup.
 - Font size control input now sits inside a button that toggles a preset-size dropdown and has a rounded border.
 - Action bar now hides during widget drag or resize and reappears at the new position.
 - User editor color picker now opens via a circle button showing the current color.


### PR DESCRIPTION
## Summary
- sanitize custom widget HTML before inserting into shadow DOM
- sanitize HTML fetched for page layout partials
- document sanitization fix in changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685261224c6c8328b495c2e6c8a180fd