### PR TITLE
Improve text edit autolock

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -5,6 +5,7 @@ import { createColorPicker } from './colorPicker.js';
 let toolbar = null;
 let activeEl = null;
 let outsideHandler = null;
+let leaveHandler = null;
 let initPromise = null;
 let autoHandler = null;
 let editingPlain = false;
@@ -294,6 +295,12 @@ function close() {
   }
   document.removeEventListener('pointerdown', outsideHandler, true);
   document.removeEventListener('mousedown', outsideHandler, true);
+  if (leaveHandler) {
+    const widget = activeEl.closest('.grid-stack-item');
+    widget?.removeEventListener('mouseleave', leaveHandler, true);
+    toolbar?.removeEventListener('mouseleave', leaveHandler, true);
+    leaveHandler = null;
+  }
   const el = activeEl;
   const cb = activeEl.__onSave;
   activeEl = null;
@@ -348,6 +355,17 @@ export async function editElement(el, onSave) {
   };
   document.addEventListener('pointerdown', outsideHandler, true);
   document.addEventListener('mousedown', outsideHandler, true);
+
+  if (startWidget) {
+    leaveHandler = ev => {
+      const to = ev.relatedTarget;
+      if (!startWidget.contains(to) && !toolbar.contains(to)) {
+        close();
+      }
+    };
+    startWidget.addEventListener('mouseleave', leaveHandler, true);
+    toolbar.addEventListener('mouseleave', leaveHandler, true);
+  }
 }
 
 export function registerElement(el, onSave) {

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -935,21 +935,9 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       selectWidget(el);
     });
 
-    // Select and temporarily lock the widget when focusing text inputs
-    el.addEventListener('focusin', e => {
-      if (!e.target.closest('input, textarea')) return;
-      selectWidget(el);
-      if (!el.dataset.tempLock) {
-        document.dispatchEvent(new CustomEvent('textEditStart', { detail: { widget: el } }));
-      }
-    });
-
-    el.addEventListener('focusout', e => {
-      if (!e.target.closest('input, textarea')) return;
-      if (el.dataset.tempLock) {
-        document.dispatchEvent(new CustomEvent('textEditStop', { detail: { widget: el } }));
-      }
-    });
+    // Older behavior locked widgets when focusing form inputs. This caused
+    // unexpected locks during regular widget interactions. The auto lock is
+    // now triggered exclusively by text editing via the global text editor.
   }
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widgets now auto-lock only during text editing and unlock when the cursor
+  leaves the widget.
 - Text color button now displays an underlined 'A' icon reflecting the selected color and opens the palette below the toolbar.
 - Color picker in user editor now floats above fields when opened.
 - Text editor toolbar now includes a floating color picker to change selected text or entire blocks.


### PR DESCRIPTION
## Summary
- fix unexpected widget locking by removing form input focus handlers
- unlock widgets when pointer leaves while editing
- document improved autolock behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685261b11c2c83288f9d6b9fd19800d2