### PR TITLE
Fix Pickr import issue

### DIFF
--- a/BlogposterCMS/public/assets/js/colorPicker.js
+++ b/BlogposterCMS/public/assets/js/colorPicker.js
@@ -1,4 +1,5 @@
-import Pickr from './vendor/pickr.min.js';
+import PickrModule from './vendor/pickr.min.js';
+const Pickr = PickrModule.default || PickrModule.Pickr || PickrModule;
 
 export function createColorPicker(options = {}) {
   const {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed module import for Pickr library to avoid runtime error.
 - Widgets lock when clicking into a text field and unlock when leaving the
   widget, keeping the editor open.
 - Pickr styles moved to /assets/css/vendor/pickr.css and loaded separately on admin pages.


### PR DESCRIPTION
## Summary
- fix color picker import by supporting multiple module formats
- note Pickr import fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68527616c79c8328b33d6e81f22517a7