### PR TITLE
Fix Pickr import causing admin UI crash

### DIFF
--- a/BlogposterCMS/public/assets/js/colorPicker.js
+++ b/BlogposterCMS/public/assets/js/colorPicker.js
@@ -1,5 +1,8 @@
-import PickrModule from './vendor/pickr.min.js';
-const Pickr = PickrModule.default || PickrModule.Pickr || PickrModule;
+// Load Pickr library which exposes a global `Pickr` when imported as a module
+// or via a script tag. The distributed `pickr.min.js` does not export a
+// default module, so we import it for its side effects and read the global.
+import './vendor/pickr.min.js';
+const Pickr = window.Pickr || globalThis.Pickr;
 
 export function createColorPicker(options = {}) {
   const {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
-<<<<<<< investigate-colorpicker.js-module-error
-- Fixed module import for Pickr library to avoid runtime error.
-=======
+- Fixed color picker import for Pickr library to avoid runtime error in the admin UI.
 - Fonts Manager now loads after all core modules. Provider registration requires a valid JWT and the internal secret.
->>>>>>> main
 - Widgets lock when clicking into a text field and unlock when leaving the
   widget, keeping the editor open.
 - Pickr styles moved to /assets/css/vendor/pickr.css and loaded separately on admin pages.


### PR DESCRIPTION
## Summary
- load Pickr as a side-effect module
- reference Pickr from global scope
- clean up changelog merge markers and document the fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68528f855d648328acabd7d0e0f43fea