### PR TITLE
Fix Pickr initialization error

### DIFF
--- a/BlogposterCMS/public/assets/js/colorPicker.js
+++ b/BlogposterCMS/public/assets/js/colorPicker.js
@@ -49,9 +49,14 @@ export function createColorPicker(options = {}) {
     });
     const addCustom = document.createElement('div');
     addCustom.className = 'color-circle add-custom';
+    // Append element before initializing Pickr so the library
+    // can safely replace it during its build process
+    section.appendChild(addCustom);
 
     const pickr = Pickr.create({
       el: addCustom,
+      // ensure the generated picker elements live inside the section
+      container: section,
       theme: 'nano',
       default: selectedColor,
       components: {
@@ -74,7 +79,6 @@ export function createColorPicker(options = {}) {
     });
 
     pickr.on('save', () => pickr.hide());
-    section.appendChild(addCustom);
     wrapper.appendChild(section);
     container.appendChild(wrapper);
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed color picker initialization in the text editor toolbar to prevent
+  `replaceChild` errors when opening the toolbar.
 - Fixed color picker import for Pickr library to avoid runtime error in the admin UI.
 - Fonts Manager now loads after all core modules. Provider registration requires a valid JWT and the internal secret.
 - Widgets lock when clicking into a text field and unlock when leaving the


### PR DESCRIPTION
## Summary
- prevent Pickr from throwing replaceChild errors by attaching the custom color element before creating Pickr
- document the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68529856136c8328bdbb96591d51cbe8