### PR TITLE
Enable single-click editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Editing text now starts on a single click and locks the widget until the
+  pointer leaves, replacing the old double-click behavior.
 - Fixed color picker initialization in the text editor toolbar to prevent
   `replaceChild` errors when opening the toolbar.
 - Fixed color picker import for Pickr library to avoid runtime error in the admin UI.


### PR DESCRIPTION
## Summary
- start text editing on a single click instead of double-click
- auto-lock widget immediately when editing begins
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68529aec15788328abaa1a9211ac94dd