### PR TITLE
Organize preset color pickers in 6-row columns

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_color-picker.scss
+++ b/BlogposterCMS/public/assets/scss/components/_color-picker.scss
@@ -4,8 +4,9 @@
   gap: 8px;
 
   .color-section {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-auto-flow: column;
+    grid-template-rows: repeat(6, 24px);
     gap: 6px;
     align-items: center;
   }

--- a/BlogposterCMS/public/assets/scss/vendor/_pickr.scss
+++ b/BlogposterCMS/public/assets/scss/vendor/_pickr.scss
@@ -17,7 +17,7 @@
 .pcr-app.visible{transition:opacity .3s;visibility:visible;opacity:1}
 .pcr-app .pcr-swatches{display:flex;flex-wrap:wrap;margin-top:.75em}
 .pcr-app .pcr-swatches.pcr-last{margin:0}
-@supports(display: grid){.pcr-app .pcr-swatches{display:grid;align-items:center;grid-template-columns:repeat(auto-fit, 1.75em)}}
+@supports(display: grid){.pcr-app .pcr-swatches{display:grid;align-items:center;grid-auto-flow:column;grid-template-rows:repeat(6, 1.75em)}}
 .pcr-app .pcr-swatches>button{font-size:1em;position:relative;width:calc(1.75em - 5px);height:calc(1.75em - 5px);border-radius:.15em;cursor:pointer;margin:2.5px;flex-shrink:0;justify-self:center;transition:all .15s;overflow:hidden;background:rgba(0,0,0,0);z-index:1}
 .pcr-app .pcr-swatches>button::before{position:absolute;content:"";top:0;left:0;width:100%;height:100%;background:url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 2'><path fill='white' d='M1,0H2V1H1V0ZM0,1H1V2H0V1Z'/><path fill='gray' d='M0,0H1V1H0V0ZM1,1H2V2H1V1Z'/></svg>");background-size:6px;border-radius:.15em;z-index:-1}
 .pcr-app .pcr-swatches>button::after{content:"";position:absolute;top:0;left:0;width:100%;height:100%;background:var(--pcr-color);border:1px solid rgba(0,0,0,.05);border-radius:.15em;box-sizing:border-box}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Color picker swatches now wrap after six rows to keep columns compact.
+- Preset color pickers in the user editor and page builder now organize
+  swatches into six-row columns for a consistent layout.
 - Editing text now starts on a single click and locks the widget until the
   pointer leaves, replacing the old double-click behavior.
 - Fixed color picker initialization in the text editor toolbar to prevent


### PR DESCRIPTION
## Summary
- organize preset color swatches in 6 rows before wrapping
- document the preset color picker layout change in the changelog

## Testing
- `npm test --silent --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_68529d5bd324832882cc6a04b89d3d04