### PR TITLE
Lock widget during input focus

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -623,13 +623,35 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     const widget = e.detail?.widget;
     if (!widget) return;
     if (widget.getAttribute('gs-locked') === 'true') return;
+    selectWidget(widget);
     autoLockWidget(widget, true);
-    grid.clearSelection();
   });
 
   document.addEventListener('textEditStop', e => {
     const widget = e.detail?.widget;
     if (!widget || widget.dataset.tempLock !== 'true') return;
+    autoLockWidget(widget, false);
+    selectWidget(widget);
+  });
+
+  document.addEventListener('focusin', e => {
+    const el = e.target;
+    if (!(el instanceof HTMLElement)) return;
+    if (!['INPUT', 'TEXTAREA'].includes(el.tagName)) return;
+    const widget = el.closest('.grid-stack-item');
+    if (!widget || widget.getAttribute('gs-locked') === 'true') return;
+    selectWidget(widget);
+    autoLockWidget(widget, true);
+  });
+
+  document.addEventListener('focusout', e => {
+    const el = e.target;
+    if (!(el instanceof HTMLElement)) return;
+    if (!['INPUT', 'TEXTAREA'].includes(el.tagName)) return;
+    const widget = el.closest('.grid-stack-item');
+    if (!widget || widget.dataset.tempLock !== 'true') return;
+    const to = e.relatedTarget;
+    if (to && widget.contains(to)) return;
     autoLockWidget(widget, false);
     selectWidget(widget);
   });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Form inputs inside widgets now auto-lock their parent on focus and
+  unlock when focus leaves, ensuring they remain selected during edits.
+- Widgets remain selected when editing text. They temporarily lock on
+  text click and unlock once the pointer leaves.
 - Color picker swatches now wrap after six rows to keep columns compact.
 - Preset color pickers in the user editor and page builder now organize
   swatches into six-row columns for a consistent layout.


### PR DESCRIPTION
## Summary
- keep widgets selected when focusing form fields
- auto-lock widgets during input focus
- update changelog

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_6852a13f32708328abd8a7cb5732e86c