### PR TITLE
Improve color picker buttons

### DIFF
--- a/BlogposterCMS/public/assets/js/colorPicker.js
+++ b/BlogposterCMS/public/assets/js/colorPicker.js
@@ -35,7 +35,8 @@ export function createColorPicker(options = {}) {
     }
     colors.forEach(c => {
       if (!c) return;
-      const circle = document.createElement('div');
+      const circle = document.createElement('button');
+      circle.type = 'button';
       circle.className = 'color-circle';
       circle.style.backgroundColor = c;
       if (c === selectedColor) circle.classList.add('active');
@@ -47,7 +48,8 @@ export function createColorPicker(options = {}) {
       });
       section.appendChild(circle);
     });
-    const addCustom = document.createElement('div');
+    const addCustom = document.createElement('button');
+    addCustom.type = 'button';
     addCustom.className = 'color-circle add-custom';
     // Append element before initializing Pickr so the library
     // can safely replace it during its build process

--- a/BlogposterCMS/public/assets/scss/components/_color-picker.scss
+++ b/BlogposterCMS/public/assets/scss/components/_color-picker.scss
@@ -5,8 +5,8 @@
 
   .color-section {
     display: grid;
-    grid-auto-flow: column;
-    grid-template-rows: repeat(6, 24px);
+    grid-auto-flow: row;
+    grid-template-columns: repeat(6, 24px);
     gap: 6px;
     align-items: center;
   }
@@ -17,6 +17,8 @@
     border-radius: 50%;
     cursor: pointer;
     border: 2px solid transparent;
+    padding: 0;
+    background: none;
   }
 
   .color-circle.active {

--- a/BlogposterCMS/public/assets/scss/components/_page-editor.scss
+++ b/BlogposterCMS/public/assets/scss/components/_page-editor.scss
@@ -132,6 +132,8 @@
   border-radius: 50%;
   cursor: pointer;
   border: 2px solid transparent;
+  padding: 0;
+  background: none;
 }
 .color-circle.active {
   border-color: var(--user-color);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Preset color swatches are now rendered as buttons and layout uses six columns.
 - Color picker swatches now wrap after six rows to keep columns compact.
 - Preset color pickers in the user editor and page builder now organize
   swatches into six-row columns for a consistent layout.


### PR DESCRIPTION
## Summary
- swap preset color circles to `<button>` elements
- arrange color picker presets in six columns
- document change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852a30dd9a48328b971a960c531db40