### PR TITLE
Fix font style persistence

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -179,10 +179,17 @@ async function init() {
           activeEl.style.fontSize = val + 'px';
         }
       } else {
-        activeEl.style.fontSize = val + 'px';
-        activeEl
-          .querySelectorAll('[style*="font-size"]')
-          .forEach(el => (el.style.fontSize = val + 'px'));
+        activeEl.querySelectorAll('*').forEach(el => {
+          el.style.fontSize = val + 'px';
+        });
+        activeEl.childNodes.forEach(node => {
+          if (node.nodeType === 3 && node.textContent.trim()) {
+            const span = document.createElement('span');
+            span.style.fontSize = val + 'px';
+            span.textContent = node.textContent;
+            node.parentNode.replaceChild(span, node);
+          }
+        });
       }
       editingPlain = false;
       activeEl.focus();
@@ -223,8 +230,17 @@ async function init() {
           activeEl.style.color = val;
         }
       } else {
-        activeEl.style.color = val;
-        activeEl.querySelectorAll('[style*="color"]').forEach(el => (el.style.color = val));
+        activeEl.querySelectorAll('*').forEach(el => {
+          el.style.color = val;
+        });
+        activeEl.childNodes.forEach(node => {
+          if (node.nodeType === 3 && node.textContent.trim()) {
+            const span = document.createElement('span');
+            span.style.color = val;
+            span.textContent = node.textContent;
+            node.parentNode.replaceChild(span, node);
+          }
+        });
       }
       editingPlain = false;
       activeEl.focus();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,12 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
-<<<<<<< change-preset-color-to-buttons-and-update-layout
+- Font size and text color changes now wrap text in spans so styles persist when saving.
 - Preset color swatches are now rendered as buttons and layout uses six columns.
-=======
 - Form inputs inside widgets now auto-lock their parent on focus and
   unlock when focus leaves, ensuring they remain selected during edits.
 - Widgets remain selected when editing text. They temporarily lock on
   text click and unlock once the pointer leaves.
->>>>>>> main
 - Color picker swatches now wrap after six rows to keep columns compact.
 - Preset color pickers in the user editor and page builder now organize
   swatches into six-row columns for a consistent layout.


### PR DESCRIPTION
## Summary
- wrap entire text or selected parts in spans when applying font size or text color
- remove leftover merge markers and add entry to changelog about style persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852a5003250832888a7a2d18dd17631