### PR TITLE
Add font manager integration

### DIFF
--- a/BlogposterCMS/mother/modules/fontsManager/config/defaultFonts.js
+++ b/BlogposterCMS/mother/modules/fontsManager/config/defaultFonts.js
@@ -1,0 +1,30 @@
+// mother/modules/fontsManager/config/defaultFonts.js
+// Default fonts loaded by fontsManager on startup.
+
+module.exports.DEFAULT_FONTS = [
+  {
+    name: 'Manrope',
+    url: 'https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600&display=swap',
+    provider: 'googleFonts'
+  },
+  {
+    name: 'Work Sans',
+    url: 'https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600&display=swap',
+    provider: 'googleFonts'
+  },
+  {
+    name: 'Plus Jakarta Sans',
+    url: 'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600&display=swap',
+    provider: 'googleFonts'
+  },
+  {
+    name: 'Sora',
+    url: 'https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600&display=swap',
+    provider: 'googleFonts'
+  },
+  {
+    name: 'Oswald',
+    url: 'https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600&display=swap',
+    provider: 'googleFonts'
+  }
+];

--- a/BlogposterCMS/mother/modules/fontsManager/moduleInfo.json
+++ b/BlogposterCMS/mother/modules/fontsManager/moduleInfo.json
@@ -1,6 +1,6 @@
 {
   "moduleName": "fontsManager",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Manages font provider strategies.",
   "developer": "Blogposter Team"
 }

--- a/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-block-widget.scss
@@ -33,6 +33,51 @@
   .heading-select {
     margin-left: 8px;
   }
+  .font-family-control {
+    margin-right: 8px;
+    position: relative;
+    display: flex;
+    align-items: center;
+    border: 1px solid var(--color-secondary-light);
+    border-radius: 12px;
+    padding: 2px;
+
+    .ff-btn {
+      display: flex;
+      align-items: center;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 0 8px;
+    }
+
+    .ff-options {
+      display: none;
+      position: absolute;
+      top: 100%;
+      left: 0;
+      background: var(--color-white);
+      box-shadow: var(--shadow-default);
+      z-index: 2000;
+      max-height: 200px;
+      overflow-y: auto;
+      white-space: nowrap;
+
+      span {
+        display: block;
+        padding: 4px 8px;
+        cursor: pointer;
+
+        &:hover {
+          background: var(--color-primary-light);
+        }
+      }
+    }
+
+    &.open .ff-options {
+      display: block;
+    }
+  }
   .font-size-control {
     margin-left: 8px;
     display: flex;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fonts now load from the fonts manager so custom providers can add new fonts.
+- Added font selection dropdown to the builder text editor toolbar.
 - Font size and text color changes now wrap text in spans so styles persist when saving.
 - Preset color swatches are now rendered as buttons and layout uses six columns.
 - Form inputs inside widgets now auto-lock their parent on focus and


### PR DESCRIPTION
## Summary
- expose default font data in fontsManager
- implement listFonts and addFont events
- load fonts dynamically from fontsManager on the front-end
- bump fontsManager module version
- update changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852a6a0b3448328a16c9443ff04f143