### PR TITLE
Prevent widgets from escaping grid

### DIFF
--- a/BlogposterCMS/public/assets/js/canvasGrid.js
+++ b/BlogposterCMS/public/assets/js/canvasGrid.js
@@ -3,7 +3,13 @@
 
 export class CanvasGrid {
   constructor(options = {}, el) {
-    this.options = Object.assign({ cellHeight: 5, columnWidth: 5 }, options);
+    this.options = Object.assign(
+      { cellHeight: 5, columnWidth: 5, columns: Infinity, rows: Infinity },
+      options
+    );
+    if (Number.isFinite(this.options.column)) {
+      this.options.columns = this.options.column;
+    }
     this.el = typeof el === 'string' ? document.querySelector(el) : el;
     this.el.classList.add('canvas-grid');
     this.widgets = [];
@@ -21,11 +27,36 @@ export class CanvasGrid {
   }
 
   _applyPosition(el) {
-    const { columnWidth, cellHeight } = this.options;
-    const x = +el.getAttribute('gs-x') || 0;
-    const y = +el.getAttribute('gs-y') || 0;
-    const w = +el.getAttribute('gs-w') || 1;
-    const h = +el.getAttribute('gs-h') || 1;
+    const { columnWidth, cellHeight, columns, rows } = this.options;
+    let x = +el.getAttribute('gs-x') || 0;
+    let y = +el.getAttribute('gs-y') || 0;
+    let w = +el.getAttribute('gs-w') || 1;
+    let h = +el.getAttribute('gs-h') || 1;
+
+    w = Math.max(1, w);
+    h = Math.max(1, h);
+
+    if (Number.isFinite(columns)) {
+      if (w > columns) w = columns;
+      if (x < 0) x = 0;
+      if (x + w > columns) x = columns - w;
+    } else if (x < 0) {
+      x = 0;
+    }
+
+    if (Number.isFinite(rows)) {
+      if (h > rows) h = rows;
+      if (y < 0) y = 0;
+      if (y + h > rows) y = rows - h;
+    } else if (y < 0) {
+      y = 0;
+    }
+
+    el.setAttribute('gs-x', x);
+    el.setAttribute('gs-y', y);
+    el.setAttribute('gs-w', w);
+    el.setAttribute('gs-h', h);
+
     el.style.position = 'absolute';
     el.style.left = `${x * columnWidth}px`;
     el.style.top = `${y * cellHeight}px`;

--- a/BlogposterCMS/public/assets/scss/components/_content-area.scss
+++ b/BlogposterCMS/public/assets/scss/components/_content-area.scss
@@ -17,7 +17,7 @@
   min-height: 300px;
   position: relative;
   background: var(--color-bg);
-  overflow: visible;
+  overflow: hidden;
 }
 .canvas-item {
   position: absolute;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Canvas grid enforces boundaries so widgets stay within the grid area.
 - Removed GridStack dependency in favor of a custom drag-and-drop canvas grid.
 - Updated admin template and SCSS to use the new canvas grid classes.
 - Widget HTML edits from the toolbar now sync to the code editor, keeping custom code up to date.


### PR DESCRIPTION
## Summary
- restrict drag/resize coordinates inside CanvasGrid
- hide overflowing widgets via CSS
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852dffe9df08328ab7c6af79d038926