### PR TITLE
Improve drag ghost positioning

### DIFF
--- a/BlogposterCMS/public/assets/js/canvasGrid.js
+++ b/BlogposterCMS/public/assets/js/canvasGrid.js
@@ -60,7 +60,8 @@ export class CanvasGrid {
     el.style.position = 'absolute';
     el.style.left = '0px';
     el.style.top = '0px';
-    el.style.transform = `translate(${x * columnWidth}px, ${y * cellHeight}px)`;
+    el.style.transform =
+      `translate3d(${x * columnWidth}px, ${y * cellHeight}px, 0)`;
     el.style.width = `${w * columnWidth}px`;
     el.style.height = `${h * cellHeight}px`;
   }
@@ -173,7 +174,8 @@ export class CanvasGrid {
     const frame = () => {
       if (!dragging) return;
       const snap = this._snap(targetX, targetY);
-      ghost.style.transform = `translate(${snap.x * this.options.columnWidth}px, ${snap.y * this.options.cellHeight}px)`;
+      ghost.style.transform =
+        `translate3d(${snap.x * this.options.columnWidth}px, ${snap.y * this.options.cellHeight}px, 0)`;
       requestAnimationFrame(frame);
     };
     const move = e => {

--- a/BlogposterCMS/public/assets/scss/components/_content-area.scss
+++ b/BlogposterCMS/public/assets/scss/components/_content-area.scss
@@ -32,6 +32,7 @@
 }
 
 .drag-ghost {
+  position: absolute;
   pointer-events: none;
   opacity: 0.7;
   will-change: transform;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ El Psy Kongroo
 - Canvas grid enforces boundaries so widgets stay within the grid area.
 - Removed GridStack dependency in favor of a custom drag-and-drop canvas grid.
 - CanvasGrid drag now uses GPU-accelerated transforms with a ghost element for smoother 60fps movement.
+- Drag ghosts now use absolute positioning and translate3d for snap-to-grid
+  movement.
 - Updated admin template and SCSS to use the new canvas grid classes.
 - Widget HTML edits from the toolbar now sync to the code editor, keeping custom code up to date.
 - Fonts now load from the fonts manager so custom providers can add new fonts.


### PR DESCRIPTION
## Summary
- snap-to-grid ghosts use translate3d for smoother movement
- ensure ghost elements use absolute positioning
- document ghost position fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e4331c3c8328bff50b26b19bcba1