### PR TITLE
Fix builder drag sync

### DIFF
--- a/BlogposterCMS/public/assets/js/canvasGrid.js
+++ b/BlogposterCMS/public/assets/js/canvasGrid.js
@@ -169,13 +169,14 @@ export class CanvasGrid {
   }
 
   _enableDrag(el) {
-    let startX, startY, startGX, startGY, ghost, dragging = false;
+    let startX, startY, startGX, startGY, dragging = false;
     let targetX = 0, targetY = 0;
     const frame = () => {
       if (!dragging) return;
       const snap = this._snap(targetX, targetY);
-      ghost.style.transform =
+      el.style.transform =
         `translate3d(${snap.x * this.options.columnWidth}px, ${snap.y * this.options.cellHeight}px, 0)`;
+      this._updateBBox();
       requestAnimationFrame(frame);
     };
     const move = e => {
@@ -186,10 +187,9 @@ export class CanvasGrid {
       dragging = false;
       document.removeEventListener('mousemove', move);
       document.removeEventListener('mouseup', up);
-      ghost.remove();
       const snap = this._snap(targetX, targetY);
       this.update(el, { x: snap.x, y: snap.y });
-      el.style.visibility = '';
+      el.style.transform = '';
       this._emit('dragstop', el);
     };
     el.addEventListener('mousedown', e => {
@@ -202,13 +202,6 @@ export class CanvasGrid {
       startGY = +el.getAttribute('gs-y');
       targetX = startGX * this.options.columnWidth;
       targetY = startGY * this.options.cellHeight;
-      ghost = el.cloneNode(true);
-      ghost.classList.add('drag-ghost');
-      this.el.appendChild(ghost);
-      ghost.style.width = el.style.width;
-      ghost.style.height = el.style.height;
-      ghost.style.transform = el.style.transform;
-      el.style.visibility = 'hidden';
       dragging = true;
       this._emit('dragstart', el);
       document.addEventListener('mousemove', move);

--- a/BlogposterCMS/public/assets/scss/components/_content-area.scss
+++ b/BlogposterCMS/public/assets/scss/components/_content-area.scss
@@ -31,13 +31,6 @@
   will-change: transform;
 }
 
-.drag-ghost {
-  position: absolute;
-  pointer-events: none;
-  opacity: 0.7;
-  will-change: transform;
-}
-
 // Highlight widgets while the admin layout is editable
 body.dashboard-edit-mode .canvas-item {
   border: 2px dashed var(--user-color);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widgets now move in real time during drag operations in the builder.
 - Canvas grid enforces boundaries so widgets stay within the grid area.
 - Removed GridStack dependency in favor of a custom drag-and-drop canvas grid.
 - CanvasGrid drag now uses GPU-accelerated transforms with a ghost element for smoother 60fps movement.


### PR DESCRIPTION
## Summary
- move widgets visually during drag instead of using a ghost
- remove unused `.drag-ghost` style
- document drag behavior fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853ad8455cc8328aa951aa39fbc344f