### PR TITLE
Fix preview width limit

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -386,7 +386,7 @@ body.preview-tablet #content,
 body.preview-desktop #content {
   margin-left: auto;
   margin-right: auto;
-  max-width: var(--preview-width);
+  max-width: none;
 }
 
 .canvas-item[gs-locked="true"] > .ui-resizable-handle {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Preview mode no longer limits widget scaling; removed max-width restriction on
+  the content area.
 - Widgets now move in real time during drag operations in the builder.
 - Canvas grid enforces boundaries so widgets stay within the grid area.
 - Removed GridStack dependency in favor of a custom drag-and-drop canvas grid.


### PR DESCRIPTION
## Summary
- allow the builder preview to expand beyond the previous 1200px limit
- document widget scaling fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853b28bc4508328a2d9970583132422