### PR TITLE
Fix maintenance mode boolean handling

### DIFF
--- a/BlogposterCMS/app.js
+++ b/BlogposterCMS/app.js
@@ -840,7 +840,7 @@ app.use(async (req, res, next) => {
   
 
   // check the flag
-  const isMaintenance = await new Promise((Y, N) =>
+  const isMaintenance = await new Promise((Y, N) => {
     motherEmitter.emit(
       'getSetting',
       {
@@ -849,9 +849,13 @@ app.use(async (req, res, next) => {
         moduleType: 'core',
         key: 'MAINTENANCE_MODE'
       },
-      (err, val) => err ? N(err) : Y(val === 'true')
-    )
-  ).catch(() => false);
+      (err, val) => {
+        if (err) return N(err);
+        const str = String(val).trim().toLowerCase();
+        Y(str === 'true' || str === '1');
+      }
+    );
+  }).catch(() => false);
 
   if (isMaintenance) {
     // if we're not already on /coming-soon, rewrite there:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed maintenance mode check to accept numeric or boolean values, preventing
+  false redirects to the "Coming Soon" page.
 - Preview mode no longer limits widget scaling; removed max-width restriction on
   the content area.
 - Added basic public widgets (text, image, button, container, shape) as editable HTML blocks.


### PR DESCRIPTION
## Summary
- handle boolean maintenance mode setting
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853b7aa99988328a1b8d8fbca2b4972