### PR TITLE
Fix widget path resolution

### DIFF
--- a/BlogposterCMS/mother/modules/plainSpace/index.js
+++ b/BlogposterCMS/mother/modules/plainSpace/index.js
@@ -138,7 +138,8 @@ module.exports = {
             return callback(null, { widgets: [] }); // graceful degradation
           }
 
-          const basePublic = path.resolve(__dirname, '../../public');
+          // Resolve to CMS public directory (three levels up)
+          const basePublic = path.resolve(__dirname, '../../../public');
 
           // Filter out widgets whose JS files no longer exist
           const filtered = widgetRows.filter(row => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed false "Skipping missing widget file" warnings by correcting the
+  public directory path in the plainSpace module.
 - Builder now skips widgets whose script files are missing so deleted widgets no longer appear in the builder.
 - Removed legacy "textBlockWidget" entry; existing pages should use the new text widget.
 - Fixed maintenance mode check to accept numeric or boolean values, preventing


### PR DESCRIPTION
## Summary
- fix public directory path when verifying widget script existence
- document the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853c283ae048328a065f2e290494c5d