### PR TITLE
Add drag debug logs

### DIFF
--- a/BlogposterCMS/public/assets/js/canvasGrid.js
+++ b/BlogposterCMS/public/assets/js/canvasGrid.js
@@ -175,6 +175,7 @@ export class CanvasGrid {
       targetX = startGX * this.options.columnWidth + (e.clientX - startX);
       targetY = startGY * this.options.cellHeight + (e.clientY - startY);
       const snap = this._snap(targetX, targetY);
+      console.log(`Dragging auf X: ${snap.x}, Y: ${snap.y}`);
       el.style.transform =
         `translate3d(${snap.x * this.options.columnWidth}px, ${snap.y * this.options.cellHeight}px, 0)`;
       this._updateBBox();
@@ -184,6 +185,7 @@ export class CanvasGrid {
       document.removeEventListener('mousemove', move);
       document.removeEventListener('mouseup', up);
       const snap = this._snap(targetX, targetY);
+      console.log(`Finale Position gespeichert: translate3d(${snap.x * this.options.columnWidth}px, ${snap.y * this.options.cellHeight}px, 0)`);
       this.update(el, { x: snap.x, y: snap.y });
       el.style.transform = '';
       this._emit('dragstop', el);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Added debug console output for widget drag events to track coordinates and final positions.
 - Saving a layout template for multiple pages now sends a single batched
   request, preventing rate limit errors during bulk updates.
 - Fixed drag positions not updating visually; widgets now apply transform styles directly during mousemove.


### PR DESCRIPTION
## Summary
- log coordinates during widget drag events
- note debug addition in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853cfc0d9d883288f78b823bc9fa9f0