### PR TITLE
Fix canvas widget transform persistence

### DIFF
--- a/BlogposterCMS/public/assets/js/canvasGrid.js
+++ b/BlogposterCMS/public/assets/js/canvasGrid.js
@@ -29,8 +29,8 @@ export class CanvasGrid {
 
   _applyPosition(el) {
     const { columnWidth, cellHeight, columns, rows } = this.options;
-    let x = +el.getAttribute('gs-x') || 0;
-    let y = +el.getAttribute('gs-y') || 0;
+    let x = +el.dataset.x || 0;
+    let y = +el.dataset.y || 0;
     let w = +el.getAttribute('gs-w') || 1;
     let h = +el.getAttribute('gs-h') || 1;
 
@@ -53,8 +53,8 @@ export class CanvasGrid {
       y = 0;
     }
 
-    el.setAttribute('gs-x', x);
-    el.setAttribute('gs-y', y);
+    el.dataset.x = x;
+    el.dataset.y = y;
     el.setAttribute('gs-w', w);
     el.setAttribute('gs-h', h);
 
@@ -75,8 +75,8 @@ export class CanvasGrid {
   addWidget(opts = {}) {
     const el = document.createElement('div');
     el.className = 'canvas-item';
-    el.setAttribute('gs-x', opts.x || 0);
-    el.setAttribute('gs-y', opts.y || 0);
+    el.dataset.x = opts.x || 0;
+    el.dataset.y = opts.y || 0;
     el.setAttribute('gs-w', opts.w || 1);
     el.setAttribute('gs-h', opts.h || 1);
     this.el.appendChild(el);
@@ -93,8 +93,8 @@ export class CanvasGrid {
 
   update(el, opts = {}) {
     if (!el) return;
-    if (opts.x != null) el.setAttribute('gs-x', opts.x);
-    if (opts.y != null) el.setAttribute('gs-y', opts.y);
+    if (opts.x != null) el.dataset.x = opts.x;
+    if (opts.y != null) el.dataset.y = opts.y;
     if (opts.w != null) el.setAttribute('gs-w', opts.w);
     if (opts.h != null) el.setAttribute('gs-h', opts.h);
     if (opts.locked != null) el.setAttribute('gs-locked', opts.locked);
@@ -158,8 +158,8 @@ export class CanvasGrid {
         const rect = this.activeEl.getBoundingClientRect();
         startX = e.clientX; startY = e.clientY;
         startW = rect.width; startH = rect.height;
-        startGX = +this.activeEl.getAttribute('gs-x');
-        startGY = +this.activeEl.getAttribute('gs-y');
+        startGX = +this.activeEl.dataset.x || 0;
+        startGY = +this.activeEl.dataset.y || 0;
         this._emit('resizestart', this.activeEl);
         document.addEventListener('mousemove', move);
         document.addEventListener('mouseup', up);
@@ -185,7 +185,6 @@ export class CanvasGrid {
       document.removeEventListener('mouseup', up);
       const snap = this._snap(targetX, targetY);
       this.update(el, { x: snap.x, y: snap.y });
-      el.style.transform = '';
       this._emit('dragstop', el);
     };
     el.addEventListener('mousedown', e => {
@@ -195,8 +194,8 @@ export class CanvasGrid {
       e.preventDefault();
       this.select(el);
       startX = e.clientX; startY = e.clientY;
-      startGX = +el.getAttribute('gs-x');
-      startGY = +el.getAttribute('gs-y');
+      startGX = +el.dataset.x || 0;
+      startGY = +el.dataset.y || 0;
       targetX = startGX * this.options.columnWidth;
       targetY = startGY * this.options.cellHeight;
       dragging = true;

--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -407,8 +407,8 @@ function ensureLayout(layout = {}, lane = 'public') {
 
         const wrapper = document.createElement('div');
         wrapper.classList.add('canvas-item');
-        wrapper.setAttribute('gs-x', x);
-        wrapper.setAttribute('gs-y', y);
+        wrapper.dataset.x = x;
+        wrapper.dataset.y = y;
         wrapper.setAttribute('gs-w', w);
         wrapper.setAttribute('gs-h', h);
         wrapper.setAttribute('gs-min-w', 4);
@@ -465,8 +465,8 @@ function ensureLayout(layout = {}, lane = 'public') {
 
       const wrapper = document.createElement('div');
       wrapper.classList.add('canvas-item');
-      wrapper.setAttribute('gs-x', x);
-      wrapper.setAttribute('gs-y', y);
+      wrapper.dataset.x = x;
+      wrapper.dataset.y = y;
       wrapper.setAttribute('gs-w', w);
       wrapper.setAttribute('gs-h', h);
       wrapper.setAttribute('gs-min-w', 4);
@@ -492,8 +492,8 @@ function ensureLayout(layout = {}, lane = 'public') {
         id: el.dataset.instanceId,
         widgetId: el.dataset.widgetId,
         global: el.dataset.global === 'true',
-        x: +el.getAttribute('gs-x'),
-        y: +el.getAttribute('gs-y'),
+        x: +el.dataset.x || 0,
+        y: +el.dataset.y || 0,
         w: +el.getAttribute('gs-w'),
         h: +el.getAttribute('gs-h'),
         code: layout.find(l => l.id === el.dataset.instanceId)?.code || null

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -673,8 +673,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       id: el.dataset.instanceId,
       widgetId: el.dataset.widgetId,
       global: el.dataset.global === 'true',
-      x: +el.getAttribute('gs-x'),
-      y: +el.getAttribute('gs-y'),
+      x: +el.dataset.x || 0,
+      y: +el.dataset.y || 0,
       w: +el.getAttribute('gs-w'),
       h: +el.getAttribute('gs-h'),
       code: codeMap[el.dataset.instanceId] || null
@@ -711,8 +711,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       wrapper.dataset.widgetId = widgetDef.id;
       wrapper.dataset.instanceId = instId;
       wrapper.dataset.global = isGlobal ? 'true' : 'false';
-      wrapper.setAttribute('gs-x', item.x ?? 0);
-      wrapper.setAttribute('gs-y', item.y ?? 0);
+      wrapper.dataset.x = item.x ?? 0;
+      wrapper.dataset.y = item.y ?? 0;
       wrapper.setAttribute('gs-w', item.w ?? 8);
       wrapper.setAttribute('gs-h', item.h ?? DEFAULT_ROWS);
       wrapper.setAttribute('gs-min-w', 4);
@@ -917,8 +917,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     };
     menu.querySelector('.menu-snap').onclick = () => {
       grid.update(el, {
-        x: Math.round(+el.getAttribute('gs-x')),
-        y: Math.round(+el.getAttribute('gs-y')),
+        x: Math.round(+el.dataset.x || 0),
+        y: Math.round(+el.dataset.y || 0),
         w: Math.round(+el.getAttribute('gs-w')),
         h: Math.round(+el.getAttribute('gs-h'))
       });
@@ -986,8 +986,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     wrapper.dataset.widgetId = widgetDef.id;
     wrapper.dataset.instanceId = instId;
     wrapper.dataset.global = 'false';
-    wrapper.setAttribute('gs-x', x);
-    wrapper.setAttribute('gs-y', y);
+    wrapper.dataset.x = x;
+    wrapper.dataset.y = y;
     wrapper.setAttribute('gs-w', w);
     wrapper.setAttribute('gs-h', h);
     wrapper.setAttribute('gs-min-w', 4);

--- a/BlogposterCMS/public/assets/plainspace/admin/pagePicker.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/pagePicker.js
@@ -22,8 +22,8 @@
     pages.forEach((p, idx) => {
       const item = document.createElement('div');
       item.classList.add('canvas-item');
-      item.setAttribute('gs-x', 0);
-      item.setAttribute('gs-y', idx);
+      item.dataset.x = 0;
+      item.dataset.y = idx;
       item.setAttribute('gs-w', 4);
       item.setAttribute('gs-h', 1);
       item.setAttribute('gs-min-w', 4);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ El Psy Kongroo
 ## [Unreleased]
 - Saving a layout template for multiple pages now sends a single batched
   request, preventing rate limit errors during bulk updates.
+- Removed legacy grid positioning attributes (gs-x, gs-y); widget moves now
+  persist directly via inline transform styles.
 - Fixed drag positions not updating visually; widgets now apply transform styles directly during mousemove.
 - Fixed false "Skipping missing widget file" warnings by correcting the
   public directory path in the plainSpace module.


### PR DESCRIPTION
## Summary
- keep widget positions in inline styles instead of old gs-x/gs-y attributes
- update builder and renderer scripts to use `dataset.x` and `dataset.y`
- adjust page picker grid accordingly
- document change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853d51600dc8328bc81a0a3c8089f52