### PR TITLE
Fix grid width restrictions

### DIFF
--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -395,7 +395,7 @@ function ensureLayout(layout = {}, lane = 'public') {
       gridEl.className = 'canvas-grid';
       contentEl.appendChild(gridEl);
       // Static mode: public pages should not be directly editable
-      const grid = initCanvasGrid({ staticGrid: true, float: true, cellHeight: 5, columnWidth: 5, column: 64 }, gridEl);
+      const grid = initCanvasGrid({ staticGrid: true, float: true, cellHeight: 5, columnWidth: 5 }, gridEl);
 
       items.forEach(item => {
         const def = allWidgets.find(w => w.id === item.widgetId);
@@ -448,7 +448,7 @@ function ensureLayout(layout = {}, lane = 'public') {
     gridEl.id = 'adminGrid';
     gridEl.className = 'canvas-grid';
     contentEl.appendChild(gridEl);
-    const grid = initCanvasGrid({ cellHeight: 5, columnWidth: 5, column: 64 }, gridEl);
+    const grid = initCanvasGrid({ cellHeight: 5, columnWidth: 5 }, gridEl);
     grid.setStatic(true);
     grid.on('change', () => {});
     window.adminGrid = grid;

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -604,7 +604,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   gridEl = document.getElementById('builderGrid');
   await applyBuilderTheme();
   // Enable floating mode for easier widget placement in the builder
-  const grid = initCanvasGrid({ float: true, cellHeight: 5, columnWidth: 5, column: 64 }, gridEl);
+  const grid = initCanvasGrid({ float: true, cellHeight: 5, columnWidth: 5 }, gridEl);
   grid.on("dragstart", () => {
     actionBar.style.display = "none";
   });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Removed hardcoded column limit from CanvasGrid so widgets can be dragged across the full width in builder and dashboard.
 - Fixed bounding box position mismatch during widget dragging by copying the
   widget's transform when updating the selection frame.
 - Selection frame now refreshes after a widget is updated so the bounding box


### PR DESCRIPTION
## Summary
- allow CanvasGrid to span the full width by removing the fixed column limit
- document the change in the changelog

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_6853e2c9a8d88328a5cd26da09baebf7