### PR TITLE
Refactor public widgets

### DIFF
--- a/BlogposterCMS/mother/modules/plainSpace/config/defaultWidgets.js
+++ b/BlogposterCMS/mother/modules/plainSpace/config/defaultWidgets.js
@@ -131,38 +131,10 @@ module.exports.DEFAULT_WIDGETS = [
     category: 'core'
   },
   {
-    widgetId: 'textBlock',
+    widgetId: 'htmlBlock',
     widgetType: PUBLIC_LANE,
-    label: 'Text Block',
-    content: '/assets/plainspace/public/basicwidgets/textWidget.js',
-    category: 'basic'
-  },
-  {
-    widgetId: 'imageBlock',
-    widgetType: PUBLIC_LANE,
-    label: 'Image Block',
-    content: '/assets/plainspace/public/basicwidgets/imageWidget.js',
-    category: 'basic'
-  },
-  {
-    widgetId: 'buttonBlock',
-    widgetType: PUBLIC_LANE,
-    label: 'Button Block',
-    content: '/assets/plainspace/public/basicwidgets/buttonWidget.js',
-    category: 'basic'
-  },
-  {
-    widgetId: 'containerBlock',
-    widgetType: PUBLIC_LANE,
-    label: 'Container Block',
-    content: '/assets/plainspace/public/basicwidgets/containerWidget.js',
-    category: 'basic'
-  },
-  {
-    widgetId: 'shapeBlock',
-    widgetType: PUBLIC_LANE,
-    label: 'Shape Block',
-    content: '/assets/plainspace/public/basicwidgets/shapeWidget.js',
+    label: 'HTML Block',
+    content: '/assets/plainspace/public/htmlWidget.js',
     category: 'basic'
   }
 ];

--- a/BlogposterCMS/public/assets/plainspace/public/basicwidgets/buttonWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/basicwidgets/buttonWidget.js
@@ -1,3 +1,0 @@
-export function render(el) {
-  el.innerHTML = '<button class="button-widget">Click Me</button>';
-}

--- a/BlogposterCMS/public/assets/plainspace/public/basicwidgets/containerWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/basicwidgets/containerWidget.js
@@ -1,3 +1,0 @@
-export function render(el) {
-  el.innerHTML = '<div class="container-widget">Container</div>';
-}

--- a/BlogposterCMS/public/assets/plainspace/public/basicwidgets/imageWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/basicwidgets/imageWidget.js
@@ -1,3 +1,0 @@
-export function render(el) {
-  el.innerHTML = '<img class="image-widget" src="/assets/images/abstract-gradient-bg.png" alt="Image" />';
-}

--- a/BlogposterCMS/public/assets/plainspace/public/basicwidgets/shapeWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/basicwidgets/shapeWidget.js
@@ -1,3 +1,0 @@
-export function render(el) {
-  el.innerHTML = '<div class="shape-widget"></div>';
-}

--- a/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textWidget.js
@@ -1,3 +1,0 @@
-export function render(el) {
-  el.innerHTML = '<p class="text-widget">Edit this text</p>';
-}

--- a/BlogposterCMS/public/assets/plainspace/public/htmlWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/htmlWidget.js
@@ -1,0 +1,3 @@
+export function render(el) {
+  el.innerHTML = '<div class="html-widget">Edit HTML</div>';
+}

--- a/BlogposterCMS/public/assets/scss/components/_basic-widgets.scss
+++ b/BlogposterCMS/public/assets/scss/components/_basic-widgets.scss
@@ -1,29 +1,5 @@
-.text-widget,
-.image-widget,
-.button-widget,
-.container-widget,
-.shape-widget {
+// components/_basic-widgets.scss
+.html-widget {
   width: 100%;
   height: 100%;
-}
-
-.image-widget {
-  display: block;
-  max-width: 100%;
-}
-
-.button-widget {
-  padding: 8px 16px;
-  background: var(--color-primary);
-  color: var(--color-white);
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.shape-widget {
-  width: 50px;
-  height: 50px;
-  background: var(--color-primary-light);
-  border-radius: 50%;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Replaced all default public widgets with a single HTML Block widget for custom markup.
 - Removed hardcoded column limit from CanvasGrid so widgets can be dragged across the full width in builder and dashboard.
 - Fixed bounding box position mismatch during widget dragging by copying the
   widget's transform when updating the selection frame.


### PR DESCRIPTION
## Summary
- remove basic public widgets
- add HTML Block widget as only default public widget
- style `.html-widget` to fill its grid area
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853fdbb5af88328abd5b0305f6390e2