### PR TITLE
Improve builder autosave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Builder autosave is now debounced and only triggers when the layout changes.
+  A 30 second fallback interval ensures progress is still saved without flooding
+  the server.
 - Removed hardcoded column limit from CanvasGrid so widgets can be dragged across the full width in builder and dashboard.
 - Fixed bounding box position mismatch during widget dragging by copying the
   widget's transform when updating the selection frame.


### PR DESCRIPTION
## Summary
- debounce layout autosave and avoid saving unchanged layouts
- fall back to 30s autosave interval
- update autosave triggers after widget actions
- document reduced autosave traffic in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853fe9621148328aaf7a77a8a3a74cc