### PR TITLE
Fix builder widget content sizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /mother/modeMiddleware.js
 public/assets/css/site.css
 public/assets/css/site.css.map
+BlogposterCMS/public/build/
 fix.patch
 
 # Logs

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -328,6 +328,12 @@ body.builder-mode #builderGrid {
   min-height: 100%;
 }
 
+// Ensure themed widget content matches its wrapper dimensions
+body.builder-mode .canvas-item-content.builder-themed {
+  width: 100%;
+  height: 100%;
+}
+
 body.builder-mode #top-header,
 body.builder-mode #main-header {
   display: none;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Builder: `.canvas-item-content.builder-themed` now fills its parent so the bounding box matches widget dimensions.
 - Replaced all public widgets with a single HTML Block blueprint.
 - CanvasGrid now emits global events for mouse, touch, keyboard and window
   interactions, enabling centralized handling in the builder and dashboard.


### PR DESCRIPTION
## Summary
- ensure `.canvas-item-content.builder-themed` fills its parent in builder mode
- document the fix in the changelog
- ignore build output in git

## Testing
- `npm run build`
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_68540679f4ec8328b7508381f399e551