### PR TITLE
Fix widget code editor missing HTML

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -511,7 +511,13 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
           codeData.sourceJs = '';
         }
       }
-      htmlEl.value = codeData.html || '';
+      if (codeData.html) {
+        htmlEl.value = codeData.html;
+      } else {
+        const root = el.querySelector('.canvas-item-content')?.shadowRoot;
+        const container = root?.querySelector('.widget-container');
+        htmlEl.value = container ? container.innerHTML.trim() : '';
+      }
       overlay.querySelector('.editor-css').value = codeData.css || '';
       jsEl.value = codeData.js || '';
       overlay.defaultJs = codeData.sourceJs || '';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ El Psy Kongroo
 - Builder: validates HTML tags with a shared `allowedTags` list in the text editor.
 - Builder: `.canvas-item-content.builder-themed` now fills its parent so the bounding box matches widget dimensions.
 - Replaced all public widgets with a single HTML Block blueprint.
+- Opening the code editor now preloads the current widget HTML instead of showing a blank editor.
 - CanvasGrid now emits global events for mouse, touch, keyboard and window
   interactions, enabling centralized handling in the builder and dashboard.
 - Global listener binding moved to a shared module so builder components


### PR DESCRIPTION
## Summary
- load widget HTML from existing container when opening code editor
- document behavior in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68540ab3db208328bcea245cb1b5e0a3