### PR TITLE
Ensure widget container uses full size

### DIFF
--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -83,6 +83,8 @@ function renderWidget(wrapper, def, code = null, lane = 'public') {
 
   const container = document.createElement('div');
   container.className = 'widget-container';
+  container.style.width = '100%';
+  container.style.height = '100%';
   // Prevent drag actions when interacting with form controls inside widgets on
   // admin pages. Attach the handler on both the container and the grid item
   // content element so events are intercepted before the grid logic runs.

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -338,6 +338,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
 
     const container = document.createElement('div');
     container.className = 'widget-container';
+    container.style.width = '100%';
+    container.style.height = '100%';
     // Prevent drag actions when interacting with form controls inside widgets.
     // Attach the handler on both the container and the grid item content so
     // events are intercepted before the grid logic runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widget containers now enforce full width and height via inline styles to
+  prevent theme overrides.
 - Builder: validates HTML tags with a shared `allowedTags` list in the text editor.
 - Builder: `.canvas-item-content.builder-themed` now fills its parent so the bounding box matches widget dimensions.
 - Replaced all public widgets with a single HTML Block blueprint.


### PR DESCRIPTION
## Summary
- keep widget containers at 100% width and height via inline styles
- document the new behaviour in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68540dc3c2908328b8eb90e2cd458044