### PR TITLE
Add Text Box widget

### DIFF
--- a/BlogposterCMS/mother/modules/plainSpace/config/defaultWidgets.js
+++ b/BlogposterCMS/mother/modules/plainSpace/config/defaultWidgets.js
@@ -136,5 +136,12 @@ module.exports.DEFAULT_WIDGETS = [
     label: "HTML Block",
     content: "/assets/plainspace/public/basicwidgets/htmlWidget.js",
     category: "basic"
+  },
+  {
+    widgetId: "textBox",
+    widgetType: PUBLIC_LANE,
+    label: "Text Box",
+    content: "/assets/plainspace/public/basicwidgets/textBoxWidget.js",
+    category: "basic"
   }
 ];

--- a/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textBoxWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textBoxWidget.js
@@ -1,0 +1,9 @@
+export function render(el) {
+  if (!el) return;
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'textbox-widget';
+  input.placeholder = 'Lorem ipsum';
+  el.innerHTML = '';
+  el.appendChild(input);
+}

--- a/BlogposterCMS/public/assets/scss/components/_basic-widgets.scss
+++ b/BlogposterCMS/public/assets/scss/components/_basic-widgets.scss
@@ -2,3 +2,9 @@
   width: 100%;
   height: 100%;
 }
+
+.textbox-widget {
+  width: 100%;
+  padding: 0.25rem;
+  box-sizing: border-box;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ El Psy Kongroo
 ## [Unreleased]
 - Widget containers now enforce full width and height via inline styles to
   prevent theme overrides.
+- Added Text Box widget for basic input with a lorem ipsum placeholder.
 - Builder: validates HTML tags with a shared `allowedTags` list in the text editor.
 - Builder: `.canvas-item-content.builder-themed` now fills its parent so the bounding box matches widget dimensions.
 - Replaced all public widgets with a single HTML Block blueprint.


### PR DESCRIPTION
## Summary
- create `textBoxWidget` with lorem ipsum placeholder
- style the new widget in SCSS
- register the widget as a default public widget
- document the addition in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68540fa9c5c8832895e0ad4f34742f1b