### PR TITLE
Fix admin grid height

### DIFF
--- a/BlogposterCMS/public/assets/js/canvasGrid.js
+++ b/BlogposterCMS/public/assets/js/canvasGrid.js
@@ -26,6 +26,7 @@ export class CanvasGrid {
     this._emitter = new EventTarget();
     this._createBBox();
     bindGlobalListeners(this.el, (evt, e) => this._emit(evt, e));
+    this._updateGridHeight();
   }
 
   on(evt, cb) {
@@ -34,6 +35,18 @@ export class CanvasGrid {
 
   _emit(evt, detail) {
     this._emitter.dispatchEvent(new CustomEvent(evt, { detail }));
+  }
+
+  _updateGridHeight() {
+    const { cellHeight } = this.options;
+    const rows = this.widgets.reduce((m, w) => {
+      const y = +w.dataset.y || 0;
+      const h = +w.getAttribute('gs-h') || 1;
+      return Math.max(m, y + h);
+    }, 0);
+    const min = parseFloat(getComputedStyle(this.el).minHeight) || 0;
+    const height = Math.max(rows * cellHeight, min);
+    this.el.style.height = `${height}px`;
   }
 
   _applyPosition(el) {
@@ -79,6 +92,7 @@ export class CanvasGrid {
     this._enableDrag(el);
     this.widgets.push(el);
     if (this.pushOnOverlap) this._resolveCollisions(el);
+    this._updateGridHeight();
     this._emit('change', el);
   }
 
@@ -97,6 +111,7 @@ export class CanvasGrid {
   removeWidget(el) {
     if (el.parentNode === this.el) {
       el.remove();
+      this._updateGridHeight();
       this._emit('change', el);
     }
   }
@@ -113,6 +128,7 @@ export class CanvasGrid {
     this._applyPosition(el);
     if (this.pushOnOverlap) this._resolveCollisions(el);
     if (el === this.activeEl) this._updateBBox();
+    this._updateGridHeight();
     this._emit('change', el);
   }
 

--- a/BlogposterCMS/public/assets/scss/components/_content-area.scss
+++ b/BlogposterCMS/public/assets/scss/components/_content-area.scss
@@ -12,12 +12,13 @@
   }
   
 .canvas-grid {
-  width: 100%;          
-  min-width: 600px;      
+  width: 100%;
+  min-width: 600px;
   min-height: 300px;
   position: relative;
   background: var(--color-bg);
-  overflow: hidden;
+  overflow: visible;
+  height: auto;
 }
 .canvas-item {
   position: absolute;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Admin grid height now expands automatically to fit widgets.
 - CanvasGrid gained an optional push mode so builder widgets can't overlap.
 - Widget containers now enforce full width and height via inline styles to
   prevent theme overrides.


### PR DESCRIPTION
## Summary
- auto-update canvas grid height to prevent hidden widgets
- allow overflow and auto-height in canvas grid CSS
- update changelog

## Testing
- `npm test --silent`
- `npm run placeholder-parity --silent`


------
https://chatgpt.com/codex/tasks/task_e_685417f8cee88328ac723c12c904c079