### PR TITLE
Implement percentage sizing for admin widgets

### DIFF
--- a/BlogposterCMS/public/assets/js/canvasGrid.js
+++ b/BlogposterCMS/public/assets/js/canvasGrid.js
@@ -10,7 +10,8 @@ export class CanvasGrid {
         columnWidth: 5,
         columns: Infinity,
         rows: Infinity,
-        pushOnOverlap: false
+        pushOnOverlap: false,
+        percentageMode: false
       },
       options
     );
@@ -27,6 +28,11 @@ export class CanvasGrid {
     this._createBBox();
     bindGlobalListeners(this.el, (evt, e) => this._emit(evt, e));
     this._updateGridHeight();
+    if (this.options.percentageMode) {
+      window.addEventListener('resize', () => {
+        this.widgets.forEach(w => this._applyPosition(w));
+      });
+    }
   }
 
   on(evt, cb) {
@@ -83,8 +89,15 @@ export class CanvasGrid {
     el.style.position = 'absolute';
     el.style.transform =
       `translate3d(${x * columnWidth}px, ${y * cellHeight}px, 0)`;
-    el.style.width = `${w * columnWidth}px`;
-    el.style.height = `${h * cellHeight}px`;
+    if (this.options.percentageMode) {
+      const gridW = this.el.clientWidth || 1;
+      const gridH = this.el.clientHeight || 1;
+      el.style.width = `${(w * columnWidth / gridW) * 100}%`;
+      el.style.height = `${(h * cellHeight / gridH) * 100}%`;
+    } else {
+      el.style.width = `${w * columnWidth}px`;
+      el.style.height = `${h * cellHeight}px`;
+    }
   }
 
   makeWidget(el) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ El Psy Kongroo
 - Builder: `.canvas-item-content.builder-themed` now fills its parent so the bounding box matches widget dimensions.
 - Replaced all public widgets with a single HTML Block blueprint.
 - Opening the code editor now preloads the current widget HTML instead of showing a blank editor.
+- CanvasGrid can size widgets in percentages for responsive layouts via the new `percentageMode` option.
 - CanvasGrid now emits global events for mouse, touch, keyboard and window
   interactions, enabling centralized handling in the builder and dashboard.
 - Global listener binding moved to a shared module so builder components


### PR DESCRIPTION
## Summary
- add optional `percentageMode` to CanvasGrid
- support percentage-based widget sizing for responsive layouts
- document the new feature in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68541bc424ac83289506ee4fafd37a8f