### PR TITLE
Implement header pro mode toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Builder header menu now includes a Pro Mode toggle to switch between visual editing and direct HTML/CSS/JS editing.
 - Admin grid height now expands automatically to fit widgets.
 - CanvasGrid gained an optional push mode so builder widgets can't overlap.
 - Widget containers now enforce full width and height via inline styles to


### PR DESCRIPTION
## Summary
- move pro mode toggle to builder header menu
- hide edit buttons when pro mode off and enable contenteditable for live editing
- remove obsolete user-mode button styling
- document pro mode header toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685419525e2c8328a8664832d0de616e