### PR TITLE
Fix editor toolbar for shadow widgets

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -38,7 +38,7 @@ function isEditableElement(el) {
 function withinGridItem(el) {
   let node = el;
   while (node && node !== document.body) {
-    if (node.classList && node.classList.contains('grid-stack-item')) return true;
+    if (node.classList && node.classList.contains('canvas-item')) return true;
     node = node.parentElement || (node.getRootNode && node.getRootNode().host);
   }
   return false;
@@ -368,9 +368,18 @@ async function init() {
   await initPromise;
 }
 
+function findWidget(el) {
+  let node = el;
+  while (node && node !== document.body) {
+    if (node.classList && node.classList.contains('canvas-item')) return node;
+    node = node.parentElement || (node.getRootNode && node.getRootNode().host);
+  }
+  return null;
+}
+
 function close() {
   if (!activeEl) return;
-  const widget = activeEl.closest('.grid-stack-item');
+  const widget = findWidget(activeEl);
   if (widget) {
     document.dispatchEvent(new CustomEvent('textEditStop', { detail: { widget } }));
   }
@@ -391,7 +400,7 @@ function close() {
   document.removeEventListener('pointerdown', outsideHandler, true);
   document.removeEventListener('mousedown', outsideHandler, true);
   if (leaveHandler) {
-    const widget = activeEl.closest('.grid-stack-item');
+    const widget = findWidget(activeEl);
     widget?.removeEventListener('mouseleave', leaveHandler, true);
     toolbar?.removeEventListener('mouseleave', leaveHandler, true);
     leaveHandler = null;
@@ -415,7 +424,7 @@ export async function editElement(el, onSave) {
   if (activeEl === el) return;
   if (activeEl) close();
   activeEl = el;
-  const startWidget = el.closest('.grid-stack-item');
+  const startWidget = findWidget(el);
   // Immediately lock the widget so it cannot be moved while editing.
   activeEl.__onSave = onSave;
 

--- a/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textBoxWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textBoxWidget.js
@@ -1,9 +1,11 @@
+import { registerElement } from '../../../js/globalTextEditor.js';
+
 export function render(el) {
   if (!el) return;
-  const input = document.createElement('input');
-  input.type = 'text';
-  input.className = 'textbox-widget';
-  input.placeholder = 'Lorem ipsum';
+  const block = document.createElement('div');
+  block.className = 'textbox-widget';
+  block.textContent = 'Lorem ipsum dolor sit amet';
   el.innerHTML = '';
-  el.appendChild(input);
+  el.appendChild(block);
+  registerElement(block);
 }

--- a/BlogposterCMS/public/assets/scss/components/_basic-widgets.scss
+++ b/BlogposterCMS/public/assets/scss/components/_basic-widgets.scss
@@ -7,4 +7,6 @@
   width: 100%;
   padding: 0.25rem;
   box-sizing: border-box;
+  min-height: 1rem;
+  cursor: text;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Refactored Text Box widget to support inline edits in both Pro and normal modes using the global editor.
+- Text editor toolbar now locates widgets across shadow roots, ensuring it opens when clicking text inside widget containers.
+- Builder text editor now only targets `.canvas-item` widgets, dropping legacy `.grid-stack-item` checks.
+- Fixed global text editor toolbar not opening when clicking text in the builder.
 - Builder header menu now includes a Pro Mode toggle to switch between visual editing and direct HTML/CSS/JS editing.
 - Admin grid height now expands automatically to fit widgets.
 - CanvasGrid gained an optional push mode so builder widgets can't overlap.


### PR DESCRIPTION
## Summary
- make globalTextEditor find canvas widgets across shadow roots
- register Text Block widget with the global editor
- document the fixes in the changelog


------
https://chatgpt.com/codex/tasks/task_e_6854264ceff88328863c4fb0f9eecc98