### PR TITLE
Fix toolbar floating style

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
@@ -1,0 +1,72 @@
+/* =============================================================================
+   components/_text-editor-toolbar.scss
+   Styles for the floating text block editor toolbar
+   ============================================================================= */
+
+.text-block-editor-toolbar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px;
+  background: var(--color-white);
+  border: 1px solid #eee;
+  border-radius: 8px;
+  box-shadow: var(--shadow-default);
+  z-index: 1000;
+
+  &.floating {
+    position: absolute;
+  }
+
+  .tb-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    line-height: 1;
+    color: var(--color-text);
+
+    &:hover {
+      background: var(--color-secondary-light);
+    }
+  }
+
+  .font-family-control,
+  .font-size-control {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .ff-options,
+  .fs-options {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: var(--color-white);
+    border: 1px solid #eee;
+    box-shadow: var(--shadow-default);
+    border-radius: 4px;
+    padding: 4px;
+    z-index: 1000;
+
+    span {
+      display: block;
+      padding: 2px 4px;
+      cursor: pointer;
+
+      &:hover {
+        background: var(--color-secondary-light);
+      }
+    }
+  }
+}

--- a/BlogposterCMS/public/assets/scss/site.scss
+++ b/BlogposterCMS/public/assets/scss/site.scss
@@ -27,6 +27,7 @@
 @import 'components/builder';
 @import 'components/heading-widget';
 @import 'components/page-editor';
+@import 'components/text-editor-toolbar';
 @import 'components/basic-widgets';
 @import 'components/widget-options';
 @import 'pages/users';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Restored floating toolbar styling for the global text editor via new SCSS component.
 - Refactored Text Box widget to support inline edits in both Pro and normal modes using the global editor.
 - Text editor toolbar now locates widgets across shadow roots, ensuring it opens when clicking text inside widget containers.
 - Builder text editor now only targets `.canvas-item` widgets, dropping legacy `.grid-stack-item` checks.


### PR DESCRIPTION
## Summary
- restore styling for text block editor toolbar
- import toolbar styles
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685515112dc88328b80221357a1bcf94