### PR TITLE
Add global layout overlay

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -46,6 +46,10 @@
   flex: 1;
 }
 
+.builder-header .global-layout-toggle {
+  margin-left: 8px;
+}
+
 .builder-header .page-link {
   color: var(--color-primary);
 }
@@ -426,13 +430,37 @@ body.preview-desktop #content {
 .builder-version {
   position: fixed;
   left: 0;
-  bottom: 0;
+  bottom: 32px;
   padding: 2px 4px;
   font-size: 10px;
   color: var(--color-text);
   background: rgba(255, 255, 255, 0.6);
   pointer-events: none;
   z-index: 50;
+}
+
+.layout-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  gap: 4px;
+  padding: 4px 8px;
+  background: var(--color-white);
+  border-top: 1px solid #eee;
+  z-index: 60;
+
+  button {
+    background: transparent;
+    border: none;
+    padding: 4px 8px;
+    cursor: pointer;
+  }
+
+  .active {
+    font-weight: 600;
+  }
 }
 
 .bounding-box {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Layout templates can now be marked as global via an `is_global` flag and edited directly in the builder.
 - Builder header menu now includes a Pro Mode toggle to switch between visual editing and direct HTML/CSS/JS editing.
 - Admin grid height now expands automatically to fit widgets.
 - CanvasGrid gained an optional push mode so builder widgets can't overlap.
@@ -18,6 +19,8 @@ El Psy Kongroo
 - Replaced all public widgets with a single HTML Block blueprint.
 - Opening the code editor now preloads the current widget HTML instead of showing a blank editor.
 - CanvasGrid can size widgets in percentages for responsive layouts via the new `percentageMode` option.
+- Builder adds a bottom layout bar for switching between the global layout and individual layers.
+- Global layout now stays visible while switching layers; widgets track their layer with a `data-layer` attribute.
 - CanvasGrid now emits global events for mouse, touch, keyboard and window
   interactions, enabling centralized handling in the builder and dashboard.
 - Global listener binding moved to a shared module so builder components


### PR DESCRIPTION
## Summary
- allow marking layout templates as global
- load the global layout in the builder and toggle with new checkbox
- update placeholders and service events to store `is_global`
- style checkbox in builder header
- document global layout support

## Testing
- `npm --prefix BlogposterCMS test`
- `npm --prefix BlogposterCMS run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_68545e6382588328b16b1eb11779f98c