### PR TITLE
Fix builder header fallback

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -1137,7 +1137,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     }
     const [x, y, w, h] = [
       Math.floor((relX / rect.width) * 64) || 0,
-      Math.floor((relY / rect.height) * 6) || 0,
+      Math.floor((relY / rect.height) * DEFAULT_ROWS) || 0,
       8,
       DEFAULT_ROWS
     ];
@@ -1316,11 +1316,10 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   });
 
   const appScope = document.querySelector('.app-scope');
-  const mainContent = document.querySelector('.main-content');
   if (appScope) {
     appScope.prepend(topBar);
-  } else if (contentEl) {
-    contentEl.prepend(topBar);
+  } else {
+    document.body.prepend(topBar);
   }
 
   startAutosave();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Builder header now attaches to `.app-scope` when present and falls back to the
+  document body to ensure visibility in all layouts.
+- Fixed widget dropping positions by basing Y coordinates on `DEFAULT_ROWS`.
 - Ensured builder header always mounts at the top of the page and improved
   widget drop coordinate detection for touch devices.
 - Improved builder header visibility by raising its z-index and added safer widget drop coordinate calculation.


### PR DESCRIPTION
## Summary
- ensure builder header mounts even if `.app-scope` is missing
- document header fallback in CHANGELOG

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6855225b27a48328bf41242f9a2078e0