### PR TITLE
Fix meltdownEmit payload handling

### DIFF
--- a/BlogposterCMS/mother/emitters/motherEmitter.js
+++ b/BlogposterCMS/mother/emitters/motherEmitter.js
@@ -189,7 +189,9 @@ class MotherEmitter extends EventEmitter {
     // (2) minimal payload check
     const firstArg = args[0];
     if (!firstArg || typeof firstArg !== 'object' || !firstArg.moduleName) {
-      console.warn('[MotherEmitter] WARNING: Event="%s" missing \'moduleName\' in firstArg => ignoring.', eventName);
+      console.warn('[MotherEmitter] WARNING: Event="%s" missing \'moduleName\' in firstArg => returning error.', eventName);
+      const cb = args.find(a => typeof a === 'function');
+      if (cb) cb(new Error('Missing moduleName in payload'));
       return false;
     }
 

--- a/BlogposterCMS/public/assets/js/meltdownEmitter.js
+++ b/BlogposterCMS/public/assets/js/meltdownEmitter.js
@@ -1,6 +1,13 @@
 // public/assets/js/meltdownEmitter.js
 ;(function(window) {
-  window.meltdownEmit = async function(eventName, payload = {}) {
+  function fetchWithTimeout(resource, options = {}, timeout = 10000) {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
+    const opts = { ...options, signal: controller.signal };
+    return fetch(resource, opts).finally(() => clearTimeout(id));
+  }
+
+  window.meltdownEmit = async function(eventName, payload = {}, timeout = 10000) {
     if (
       (eventName === 'openExplorer' || eventName === 'openMediaExplorer') &&
       window._openMediaExplorer
@@ -32,12 +39,12 @@
       });
     }
 
-    const resp = await fetch('/api/meltdown', {
+    const resp = await fetchWithTimeout('/api/meltdown', {
       method: 'POST',
       credentials: 'same-origin',
       headers,
       body: JSON.stringify({ eventName, payload })
-    });
+    }, timeout);
 
     let json;
     let rawText;
@@ -68,7 +75,7 @@
   };
 
   // Batch multiple meltdown events in one request
-  window.meltdownEmitBatch = async function(events = [], jwt = null) {
+  window.meltdownEmitBatch = async function(events = [], jwt = null, timeout = 10000) {
     if (!Array.isArray(events) || events.length === 0) return [];
 
     const headers = {
@@ -88,12 +95,12 @@
       });
     }
 
-    const resp = await fetch('/api/meltdown/batch', {
+    const resp = await fetchWithTimeout('/api/meltdown/batch', {
       method: 'POST',
       credentials: 'same-origin',
       headers,
       body: JSON.stringify({ events })
-    });
+    }, timeout);
 
     let json;
     let rawText;

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -908,7 +908,9 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
 
       try {
         const globalRes = await meltdownEmit('getGlobalLayoutTemplate', {
-          jwt: window.ADMIN_TOKEN
+          jwt: window.ADMIN_TOKEN,
+          moduleName: 'plainspace',
+          moduleType: 'core'
         });
         layoutLayers[0].layout = Array.isArray(globalRes?.layout) ? globalRes.layout : [];
         globalLayoutName = globalRes?.name || null;
@@ -922,7 +924,9 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   else {
     try {
       const globalRes = await meltdownEmit('getGlobalLayoutTemplate', {
-        jwt: window.ADMIN_TOKEN
+        jwt: window.ADMIN_TOKEN,
+        moduleName: 'plainspace',
+        moduleType: 'core'
       });
       layoutLayers[0].layout = Array.isArray(globalRes?.layout) ? globalRes.layout : [];
       globalLayoutName = globalRes?.name || null;
@@ -1363,7 +1367,12 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       await meltdownEmitBatch(events);
 
       if (globalToggle.checked) {
-        await meltdownEmit('setGlobalLayoutTemplate', { jwt: window.ADMIN_TOKEN, name });
+        await meltdownEmit('setGlobalLayoutTemplate', {
+          jwt: window.ADMIN_TOKEN,
+          moduleName: 'plainspace',
+          moduleType: 'core',
+          name
+        });
       }
 
       alert('Layout template saved');

--- a/BlogposterCMS/tests/motherEmitterPayload.test.js
+++ b/BlogposterCMS/tests/motherEmitterPayload.test.js
@@ -1,0 +1,17 @@
+const { motherEmitter } = require('../mother/emitters/motherEmitter');
+const EventEmitter = require('events');
+
+function createEmitter() {
+  const Cls = motherEmitter.constructor;
+  return new Cls();
+}
+
+test('emits error when moduleName is missing', done => {
+  const em = createEmitter();
+  em.on('dummy', (p, cb) => cb(null, true));
+  em.emit('dummy', { jwt: 't' }, err => {
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toMatch(/moduleName/);
+    done();
+  });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Added timeout handling for all `meltdownEmit` requests to prevent
+  indefinite UI blocking.
+- MotherEmitter now returns an error if `moduleName` is missing in the
+  payload instead of silently ignoring the event.
+- Provided `moduleName` when saving the global layout template from the
+  builder.
+- Fixed builder freeze by including `moduleName` when requesting the global layout template.
 - Prevented builder crashes when a layout partial is missing by safely
   catching `fetchPartial` errors in the renderer.
 - Builder header now attaches to `.app-scope` when present and falls back to the


### PR DESCRIPTION
## Summary
- add fetch timeout helper for meltdown requests
- return explicit error when `moduleName` is missing
- include `moduleName` when saving the global layout template
- test MotherEmitter payload check
- document changes

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_68554ba62ba48328a56ef26ed22ddf12