### PR TITLE
Implement global fetch timeouts

### DIFF
--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blogposter_cms",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "main": "app.js",
     "scripts": {
         "start": "node app.js",

--- a/BlogposterCMS/public/assets/js/install.js
+++ b/BlogposterCMS/public/assets/js/install.js
@@ -1,6 +1,6 @@
 (async () => {
   try {
-    const pubTok = await fetch('/api/meltdown', {
+    const pubTok = await window.fetchWithTimeout('/api/meltdown', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -8,7 +8,7 @@
         payload: { purpose: 'firstInstallCheck', moduleName: 'auth' }
       })
     }).then(r => r.json()).then(j => j.data);
-    const val = await fetch('/api/meltdown', {
+    const val = await window.fetchWithTimeout('/api/meltdown', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Public-Token': pubTok },
       body: JSON.stringify({
@@ -40,7 +40,7 @@ document.getElementById('installForm').addEventListener('submit', async e => {
     return;
   }
   try {
-    const resp = await fetch('/install', {
+    const resp = await window.fetchWithTimeout('/install', {
       method: 'POST',
       credentials: 'same-origin',
       headers: {

--- a/BlogposterCMS/public/assets/js/login.js
+++ b/BlogposterCMS/public/assets/js/login.js
@@ -18,7 +18,7 @@ document.getElementById('loginForm').addEventListener('submit', async e => {
   const CSRF_TOKEN = document.querySelector('meta[name="csrf-token"]').content;
 
   try {
-    const resp = await fetch('/admin/api/login', {
+    const resp = await window.fetchWithTimeout('/admin/api/login', {
       method: 'POST',
       credentials: 'same-origin',
       headers: {

--- a/BlogposterCMS/public/assets/js/meltdownEmitter.js
+++ b/BlogposterCMS/public/assets/js/meltdownEmitter.js
@@ -7,6 +7,8 @@
     return fetch(resource, opts).finally(() => clearTimeout(id));
   }
 
+  window.fetchWithTimeout = fetchWithTimeout;
+
   window.meltdownEmit = async function(eventName, payload = {}, timeout = 10000) {
     if (
       (eventName === 'openExplorer' || eventName === 'openMediaExplorer') &&

--- a/BlogposterCMS/public/assets/js/openExplorer.js
+++ b/BlogposterCMS/public/assets/js/openExplorer.js
@@ -45,7 +45,7 @@
         const form = new FormData();
         form.append('file', file);
         try {
-          const resp = await fetch(
+          const resp = await window.fetchWithTimeout(
             '/admin/api/upload?subPath=' + encodeURIComponent(currentPath),
             {
               method: 'POST',

--- a/BlogposterCMS/public/assets/js/register.js
+++ b/BlogposterCMS/public/assets/js/register.js
@@ -7,7 +7,7 @@ async function meltdownEmit(eventName, payload = {}) {
     headers['X-Public-Token'] = payload.jwt;
   }
 
-  const resp = await fetch('/api/meltdown', {
+  const resp = await window.fetchWithTimeout('/api/meltdown', {
     method: 'POST',
     headers,
     body: JSON.stringify({ eventName, payload })

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -98,7 +98,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   async function applyBuilderTheme() {
     const theme = window.ACTIVE_THEME || 'default';
     try {
-      const res = await fetch(`/themes/${theme}/theme.css`);
+      const res = await window.fetchWithTimeout(`/themes/${theme}/theme.css`);
       if (!res.ok) throw new Error('theme css fetch failed');
       const css = await res.text();
       const scoped = scopeThemeCss(css, '#builderGrid', '#builderGrid .builder-themed');
@@ -567,7 +567,9 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
 
       if (!codeData.sourceJs) {
         try {
-          const resp = await fetch(new URL(widgetDef.codeUrl, document.baseURI).href);
+          const resp = await window.fetchWithTimeout(
+            new URL(widgetDef.codeUrl, document.baseURI).href
+          );
           codeData.sourceJs = await resp.text();
         } catch (err) {
           console.error('[Builder] fetch widget source error', err);

--- a/BlogposterCMS/public/assets/plainspace/admin/fetchPartial.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/fetchPartial.js
@@ -6,7 +6,7 @@
 export async function fetchPartial(partialName, partialType = '') {
   const typePath = partialType ? `${partialType}/` : '';
   const url = `/assets/plainspace/admin/partials/${partialName}.html`;
-  const resp = await fetch(url);
+  const resp = await window.fetchWithTimeout(url);
   if (!resp.ok) {
     throw new Error(`HTTP ${resp.status} while fetching ${url}`);
   }

--- a/BlogposterCMS/public/assets/plainspace/admin/mediaExplorerWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/mediaExplorerWidget.js
@@ -46,7 +46,7 @@ export async function render(el) {
     const form = new FormData();
     form.append('file', file);
     try {
-      const resp = await fetch('/admin/api/upload?subPath=' + encodeURIComponent(currentPath), {
+      const resp = await window.fetchWithTimeout('/admin/api/upload?subPath=' + encodeURIComponent(currentPath), {
         method: 'POST',
         headers: { 'X-CSRF-Token': window.CSRF_TOKEN },
         body: form,

--- a/BlogposterCMS/public/assets/plainspace/admin/utils.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/utils.js
@@ -1,6 +1,6 @@
 // public/assets/plainspace/admin/utils.js
 async function fetchPartial(partialName, partialType = 'headers') {
-    const response = await fetch(`/assets/partials/${partialType}/${partialName}.html`);
+  const response = await window.fetchWithTimeout(`/assets/partials/${partialType}/${partialName}.html`);
     if (!response.ok) {
       throw new Error(`Partial "${partialName}" (${partialType}) not found.`);
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Applied `fetchWithTimeout` globally so stalled requests never freeze the UI.
 - Added timeout handling for all `meltdownEmit` requests to prevent
   indefinite UI blocking.
 - MotherEmitter now returns an error if `moduleName` is missing in the


### PR DESCRIPTION
## Summary
- expose `fetchWithTimeout` globally
- enforce fetch timeouts across all client scripts
- bump package version
- note global timeout usage in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68554f983bec83288a2344cbf512f884