### PR TITLE
Implement selection-required text editing

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -496,6 +496,8 @@ export function enableAutoEdit() {
     if (toolbar && toolbar.contains(ev.target)) return;
     const el = findEditableFromEvent(ev);
     if (!el) return;
+    const widget = findWidget(el);
+    if (widget && !widget.classList.contains('selected')) return;
     ev.stopPropagation();
     editElement(el, el.__onSave);
   };

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -311,6 +311,16 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     }
   }
 
+  function disableWidgetMove(widget, disabled) {
+    if (!widget) return;
+    grid.update(widget, { noMove: disabled });
+    if (disabled) {
+      widget.dataset.tempLock = 'true';
+    } else {
+      widget.removeAttribute('data-temp-lock');
+    }
+  }
+
   function extractCssProps(el) {
     if (!el) return '';
     const style = getComputedStyle(el);
@@ -704,13 +714,13 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     if (!widget) return;
     if (widget.getAttribute('gs-locked') === 'true') return;
     selectWidget(widget);
-    autoLockWidget(widget, true);
+    disableWidgetMove(widget, true);
   });
 
   document.addEventListener('textEditStop', e => {
     const widget = e.detail?.widget;
     if (!widget || widget.dataset.tempLock !== 'true') return;
-    autoLockWidget(widget, false);
+    disableWidgetMove(widget, false);
     selectWidget(widget);
   });
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ El Psy Kongroo
 
 ## [Unreleased]
 - Applied `fetchWithTimeout` globally so stalled requests never freeze the UI.
+- Builder text editing now requires selecting a widget first; clicking text again
+  opens the floating toolbar and temporarily disables dragging while allowing
+  resizing.
 - Added timeout handling for all `meltdownEmit` requests to prevent
   indefinite UI blocking.
 - MotherEmitter now returns an error if `moduleName` is missing in the


### PR DESCRIPTION
## Summary
- require selecting a widget before the global text editor activates
- keep widgets from moving while editing text so resizing still works
- document the new editing behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685552020bb083289b21e3c78a4c7604