### PR TITLE
Improve editor toolbar style

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -50,6 +50,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   let activeLayer = 0;
   let globalLayoutName = null;
   let layoutBar;
+  let globalToggle;
 
   function showPreviewHeader() {
     if (previewHeader) return;
@@ -1213,16 +1214,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   nameInput.value = layoutName;
   infoWrap.appendChild(nameInput);
 
-  const globalToggle = document.createElement('input');
-  globalToggle.type = 'checkbox';
-  globalToggle.id = 'layoutIsGlobal';
-  globalToggle.className = 'global-layout-toggle';
-  if (layoutName === globalLayoutName) globalToggle.checked = true;
-  infoWrap.appendChild(globalToggle);
-  const globalLabel = document.createElement('label');
-  globalLabel.textContent = 'Global';
-  globalLabel.setAttribute('for', 'layoutIsGlobal');
-  infoWrap.appendChild(globalLabel);
+  // Global layout toggle moved to the layout bar
 
   const editFor = document.createElement('span');
   editFor.textContent = 'editing for';
@@ -1463,6 +1455,16 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       btn.addEventListener('click', () => switchLayer(idx));
       layoutBar.appendChild(btn);
     });
+    const toggleWrap = document.createElement('label');
+    toggleWrap.className = 'layout-global-toggle';
+    globalToggle = document.createElement('input');
+    globalToggle.type = 'checkbox';
+    globalToggle.id = 'layoutIsGlobal';
+    globalToggle.className = 'global-layout-toggle';
+    if (layoutName === globalLayoutName) globalToggle.checked = true;
+    toggleWrap.appendChild(globalToggle);
+    toggleWrap.append(' Global');
+    layoutBar.appendChild(toggleWrap);
     document.body.appendChild(layoutBar);
   }
 

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -46,9 +46,6 @@
   flex: 1;
 }
 
-.builder-header .global-layout-toggle {
-  margin-left: 8px;
-}
 
 .builder-header .page-link {
   color: var(--color-primary);
@@ -460,6 +457,13 @@ body.preview-desktop #content {
 
   .active {
     font-weight: 600;
+  }
+
+  .layout-global-toggle {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 4px;
   }
 }
 

--- a/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
@@ -4,16 +4,18 @@
    ============================================================================= */
 
 .text-block-editor-toolbar {
-  position: absolute;
-  top: 0;
-  left: 0;
+  position: fixed;
+  top: 60px; // floats just below the header
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 32px); // almost full width with small margins
   display: flex;
   align-items: center;
   gap: 4px;
   padding: 6px;
   background: var(--color-white);
   border: 1px solid #eee;
-  border-radius: 8px;
+  border-radius: 21px;
   box-shadow: var(--shadow-default);
   z-index: 1000;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Moved global layout checkbox from header to the layout bar.
+- Adjusted text editor toolbar styling: now appears below header, spans nearly
+  the full width and sports a 21px border-radius.
 - Applied `fetchWithTimeout` globally so stalled requests never freeze the UI.
 - Builder text editing now requires selecting a widget first; clicking text again
   opens the floating toolbar and temporarily disables dragging while allowing


### PR DESCRIPTION
## Summary
- style the text editor toolbar so it sits below the header and spans nearly the full page width
- document toolbar style tweaks in the changelog
- move global layout checkbox from header to layout bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855544f88588328bb8aaae31f8872fb