### PR TITLE
Improve builder text editing UX

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -496,12 +496,11 @@ export function enableAutoEdit() {
     if (toolbar && toolbar.contains(ev.target)) return;
     const el = findEditableFromEvent(ev);
     if (!el) return;
-    const widget = findWidget(el);
-    if (widget && !widget.classList.contains('selected')) return;
     ev.stopPropagation();
+    ev.preventDefault();
     editElement(el, el.__onSave);
   };
-  document.addEventListener('click', autoHandler, true);
+  document.addEventListener('dblclick', autoHandler, true);
 }
 
 if (document.body.classList.contains('builder-mode')) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Text widgets now enter editing mode only on double-click, preventing
+  accidental drags while typing.
 - Moved global layout checkbox from header to the layout bar.
 - Adjusted text editor toolbar styling: now appears below header, spans nearly
   the full width and sports a 21px border-radius.


### PR DESCRIPTION
## Summary
- require double-click to edit text widgets in builder
- document text-editing UX change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685557de1b548328a042c9e29ee4100c