### PR TITLE
Prevent text selection while dragging widgets

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -384,6 +384,7 @@ function close() {
     document.dispatchEvent(new CustomEvent('textEditStop', { detail: { widget } }));
   }
   activeEl.removeAttribute('contenteditable');
+  activeEl.style.userSelect = 'none';
   let html = editingPlain ? activeEl.textContent : activeEl.innerHTML;
   html = sanitizeHtml(html.trim());
   if (editingPlain) {
@@ -430,6 +431,7 @@ export async function editElement(el, onSave) {
 
   editingPlain = !/<[a-z][\s\S]*>/i.test(el.innerHTML.trim());
   el.setAttribute('contenteditable', 'true');
+  el.style.userSelect = 'text';
   el.focus();
   toolbar.style.display = 'flex';
 
@@ -458,6 +460,7 @@ export async function editElement(el, onSave) {
           activeEl = newEl;
           el = newEl;
           newEl.setAttribute('contenteditable', 'true');
+          newEl.style.userSelect = 'text';
           newEl.focus();
         }
       };

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -184,6 +184,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     const container = root?.querySelector('.widget-container');
     if (!container) return;
     container.setAttribute('contenteditable', 'true');
+    container.style.userSelect = 'text';
     let obs = userObservers.get(widget);
     if (obs) obs.disconnect();
     obs = new MutationObserver(() => {
@@ -201,7 +202,10 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   function stopUserMode(widget) {
     const root = widget.querySelector('.canvas-item-content')?.shadowRoot;
     const container = root?.querySelector('.widget-container');
-    container?.removeAttribute('contenteditable');
+    if (container) {
+      container.removeAttribute('contenteditable');
+      container.style.userSelect = 'none';
+    }
     const obs = userObservers.get(widget);
     if (obs) obs.disconnect();
     userObservers.delete(widget);

--- a/BlogposterCMS/public/assets/scss/_global.scss
+++ b/BlogposterCMS/public/assets/scss/_global.scss
@@ -13,6 +13,14 @@ body {
   color: var(--color-text);
 }
 
+// Prevent accidental text selection when dragging widgets
+.widget-container {
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
     /* Canvas grid relies on content-box sizing. Reset inside its container */
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ El Psy Kongroo
 ## [Unreleased]
 - Text widgets now enter editing mode only on double-click, preventing
   accidental drags while typing.
+- Widget containers disable text selection during drag; editing mode re-enables
+  it for seamless highlighting.
 - Moved global layout checkbox from header to the layout bar.
 - Adjusted text editor toolbar styling: now appears below header, spans nearly
   the full width and sports a 21px border-radius.


### PR DESCRIPTION
## Summary
- disable text selection on widget containers
- allow highlighting text when editing widgets
- document the improvement in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68555a2ea45c83288eb8200a91b9bed7