### PR TITLE
Fix text box icon mapping

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -37,7 +37,8 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     seoImageWidget: 'image',
     savePageWidget: 'save',
     contentSummary: 'activity',
-    htmlBlock: 'code'
+    htmlBlock: 'code',
+    textBox: 'type'
   };
 
   let previewHeader;

--- a/BlogposterCMS/public/assets/plainspace/admin/widgetListWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/widgetListWidget.js
@@ -16,7 +16,8 @@ export async function render(el) {
     pageSettingsWidget: 'settings',
     seoImageWidget: 'image',
     savePageWidget: 'save',
-    contentSummary: 'activity'
+    contentSummary: 'activity',
+    textBox: 'type'
   };
 
   function getIcon(id, meta) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Reused built-in `type` icon for Text Box widget; removed unused file.
 - Text widgets now enter editing mode only on double-click, preventing
   accidental drags while typing.
 - Moved global layout checkbox from header to the layout bar.


### PR DESCRIPTION
## Summary
- map the Text Box widget to the built-in `type` icon
- remove the unused `textBox.svg` file
- document icon change in the changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68555a962ac083288323ea71081312c6