### PR TITLE
Fix color picker behavior

### DIFF
--- a/BlogposterCMS/public/assets/js/colorPicker.js
+++ b/BlogposterCMS/public/assets/js/colorPicker.js
@@ -15,12 +15,33 @@ export function createColorPicker(options = {}) {
     userColors = [],
     themeColors = [],
     initialColor = presetColors[0],
-    onSelect = () => {}
+    onSelect = () => {},
+    onClose = () => {}
   } = options;
 
   let selectedColor = initialColor;
   const container = document.createElement('div');
   container.className = 'color-picker';
+
+  function hide() {
+    container.classList.add('hidden');
+  }
+
+  function showAt(x, y) {
+    container.style.left = x + 'px';
+    container.style.top = y + 'px';
+    container.classList.remove('hidden');
+  }
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'color-picker-close';
+  closeBtn.innerHTML = '&times;';
+  closeBtn.addEventListener('click', () => {
+    hide();
+    onClose();
+  });
+  container.appendChild(closeBtn);
 
   function createSection(colors, label) {
     if (!colors || !colors.length) return;
@@ -93,6 +114,8 @@ export function createColorPicker(options = {}) {
     el: container,
     getColor() {
       return selectedColor;
-    }
+    },
+    showAt,
+    hide
   };
 }

--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -11,6 +11,7 @@ let initPromise = null;
 let autoHandler = null;
 let editingPlain = false;
 let currentColor = '#000000';
+let colorPicker = null;
 
 export function sanitizeHtml(html) {
   const div = document.createElement('div');
@@ -126,7 +127,7 @@ async function init() {
     const themeColor = getComputedStyle(document.documentElement)
       .getPropertyValue('--accent-color')
       .trim();
-    const picker = createColorPicker({
+    colorPicker = createColorPicker({
       presetColors: [
         '#FF0000', '#FF4040', '#FFC0CB', '#FF00FF', '#800080', '#8A2BE2',
         '#00CED1', '#00FFFF', '#40E0D0', '#ADD8E6', '#4169E1', '#0047AB',
@@ -138,18 +139,32 @@ async function init() {
       onSelect: c => {
         applyColor(c);
         colorIcon.style.textDecorationColor = c;
-        picker.el.classList.add('hidden');
+        colorPicker.hide();
+      },
+      onClose: () => colorBtn.focus()
+    });
+    colorPicker.el.classList.add('floating', 'hidden');
+    document.body.appendChild(colorPicker.el);
+    colorBtn.addEventListener('click', () => {
+      if (colorPicker.el.classList.contains('hidden')) {
+        const rect = colorBtn.getBoundingClientRect();
+        colorPicker.showAt(
+          rect.left + window.scrollX,
+          rect.bottom + window.scrollY
+        );
+      } else {
+        colorPicker.hide();
       }
     });
-    picker.el.classList.add('hidden');
-    colorBtn.addEventListener('click', () => {
-      picker.el.classList.toggle('hidden');
-    });
-    document.addEventListener('click', ev => {
-      if (!colorWrapper.contains(ev.target)) picker.el.classList.add('hidden');
+    toolbar.addEventListener('click', ev => {
+      if (
+        !colorWrapper.contains(ev.target) &&
+        !colorPicker.el.contains(ev.target)
+      ) {
+        colorPicker.hide();
+      }
     });
     colorWrapper.appendChild(colorBtn);
-    colorWrapper.appendChild(picker.el);
     toolbar.appendChild(colorWrapper);
 
     const ffControl = toolbar.querySelector('.font-family-control');
@@ -393,6 +408,7 @@ function close() {
     activeEl.innerHTML = html;
   }
   toolbar.style.display = 'none';
+  colorPicker?.hide?.();
   const headingSelect = toolbar.querySelector('.heading-select');
   if (headingSelect) {
     headingSelect.style.display = 'none';

--- a/BlogposterCMS/public/assets/scss/components/_color-picker.scss
+++ b/BlogposterCMS/public/assets/scss/components/_color-picker.scss
@@ -39,6 +39,15 @@
     font-size: 12px;
     color: var(--color-text);
   }
+
+  .color-picker-close {
+    align-self: flex-end;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 12px;
+    color: var(--color-text);
+  }
 }
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Color picker opens outside the text editor toolbar and stays open until closed or another toolbar action is used.
 - Text widgets now enter editing mode only on double-click, preventing
   accidental drags while typing.
 - Widget containers disable text selection during drag; editing mode re-enables


### PR DESCRIPTION
## Summary
- keep toolbar color picker open until closed
- add close button and floating panel positioning
- document color picker behavior change

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68555da076e48328b27e441e1f1257d9