### PR TITLE
Fix color picker toolbar close bug

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -487,7 +487,12 @@ export async function editElement(el, onSave) {
   }
 
   outsideHandler = ev => {
-    if (!el.contains(ev.target) && !toolbar.contains(ev.target)) close();
+    if (
+      !el.contains(ev.target) &&
+      !toolbar.contains(ev.target) &&
+      !(colorPicker && colorPicker.el.contains(ev.target))
+    )
+      close();
   };
   document.addEventListener('pointerdown', outsideHandler, true);
   document.addEventListener('mousedown', outsideHandler, true);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Fixed toolbar closing when picking a color; color selections now apply correctly.
 - Color picker opens outside the text editor toolbar and stays open until closed or another toolbar action is used.
 - Reused built-in `type` icon for Text Box widget; removed unused file.
 - Text widgets now enter editing mode only on double-click, preventing


### PR DESCRIPTION
## Summary
- prevent toolbar from closing when clicking the color picker
- document the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556045d6e88328952d89df8cd34aa3