### PR TITLE
Improve font size dropdown styling

### DIFF
--- a/BlogposterCMS/public/assets/scss/_variables.scss
+++ b/BlogposterCMS/public/assets/scss/_variables.scss
@@ -8,6 +8,7 @@
   --color-secondary-light: #F5F5F5; // Hellgrau für Inputs (nicht für Cards)
   --color-text: #222222; // Dunkler für mehr Kontrast
   --color-white: #FFFFFF;
+  --color-white-dark: #F7F7F7; // Slightly darker white for dropdown controls
   --user-color: #008080; // User-selected accent color
   --color-primary: var(--user-color);
   --gradient-primary: linear-gradient(90deg, var(--user-color), #FF00FF, #FFA500);

--- a/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
@@ -41,6 +41,34 @@
     }
   }
 
+  .font-size-control {
+    background: var(--color-white-dark);
+    border-radius: 4px;
+
+    .fs-dec {
+      border-right: 1px solid var(--color-secondary-light);
+    }
+
+    .fs-inc {
+      border-left: 1px solid var(--color-secondary-light);
+    }
+
+    .fs-btn {
+      background: none;
+      border: none;
+      padding: 0;
+      cursor: pointer;
+    }
+
+    .fs-dropdown {
+      position: relative;
+
+      &.open .fs-options {
+        display: block;
+      }
+    }
+  }
+
   .font-family-control,
   .font-size-control {
     display: flex;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Updated font size control styling: dropdown uses a darker white background and
+  plus/minus buttons show subtle borders.
 - Fixed toolbar closing when picking a color; color selections now apply correctly.
 - Color picker opens outside the text editor toolbar and stays open until closed or another toolbar action is used.
 - Reused built-in `type` icon for Text Box widget; removed unused file.


### PR DESCRIPTION
## Summary
- tweak global color variables for dropdown styling
- style the font-size controls in the editor toolbar
- update changelog

## Testing
- `npm test`
- `npm run placeholder-parity`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68556205eaf0832891be4044ce9180d2