### PR TITLE
Update widget locking behavior

### DIFF
--- a/BlogposterCMS/package-lock.json
+++ b/BlogposterCMS/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "blogposter_cms",
-    "version": "0.5.3",
+    "version": "0.5.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "blogposter_cms",
-            "version": "0.5.3",
+            "version": "0.5.5",
             "dependencies": {
                 "@rc-component/color-picker": "^2.0.1",
                 "axios": "^1.7.7",

--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blogposter_cms",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "main": "app.js",
     "scripts": {
         "start": "node app.js",

--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -520,14 +520,6 @@ export async function editElement(el, onSave) {
   document.addEventListener('mousedown', outsideHandler, true);
 
   if (startWidget) {
-    leaveHandler = ev => {
-      const to = ev.relatedTarget;
-      if (!startWidget.contains(to) && !toolbar.contains(to)) {
-        close();
-      }
-    };
-    startWidget.addEventListener('mouseleave', leaveHandler, true);
-    toolbar.addEventListener('mouseleave', leaveHandler, true);
     setWidgetLock(startWidget, true);
   }
 }

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -1087,16 +1087,13 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
       if (!e.target.closest('.canvas-item-content')) return;
       if (e.target.closest('.widget-action-bar')) return;
       e.stopPropagation();
-      selectWidget(el);
-    });
-
-    el.addEventListener('dblclick', e => {
-      if (!el.classList.contains('selected')) return;
-      if (e.target.closest('.widget-action-bar')) return;
-      const editable = findRegisteredEditable(el);
-      if (editable) {
-        e.stopPropagation();
-        editElement(editable, editable.__onSave);
+      if (el.classList.contains('selected')) {
+        const editable = findRegisteredEditable(el);
+        if (editable) {
+          editElement(editable, editable.__onSave);
+        }
+      } else {
+        selectWidget(el);
       }
     });
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Widgets stay locked until clicking outside; edit mode now opens on a second
+  click of the selected widget instead of a double-click.
 - Simplified widget locking: text edit mode now locks widgets directly and
   updates the builder grid to prevent movement until editing ends, removing
   unused auto-lock functions.


### PR DESCRIPTION
## Summary
- keep widgets locked until the user clicks outside
- activate edit mode when clicking a selected widget once
- bump CMS version to 0.5.5

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685579dd27688328b98c0e7d823a14cc