### PR TITLE
Update text box widget markup

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textBoxWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textBoxWidget.js
@@ -2,10 +2,17 @@ import { registerElement } from '../../../js/globalTextEditor.js';
 
 export function render(el) {
   if (!el) return;
-  const block = document.createElement('div');
-  block.className = 'textbox-widget';
-  block.textContent = 'Lorem ipsum dolor sit amet';
+  const wrapper = document.createElement('div');
+  wrapper.className = 'textbox-widget';
+
+  const p = document.createElement('p');
+  const span = document.createElement('span');
+  span.textContent = 'Lorem ipsum dolor sit amet';
+  p.appendChild(span);
+  wrapper.appendChild(p);
+
   el.innerHTML = '';
-  el.appendChild(block);
-  registerElement(block);
+  el.appendChild(wrapper);
+
+  registerElement(span);
 }

--- a/BlogposterCMS/public/assets/scss/components/_basic-widgets.scss
+++ b/BlogposterCMS/public/assets/scss/components/_basic-widgets.scss
@@ -9,4 +9,8 @@
   box-sizing: border-box;
   min-height: 1rem;
   cursor: text;
+
+  p {
+    margin: 0;
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ El Psy Kongroo
 - Fixed toolbar closing when picking a color; color selections now apply correctly.
 - Color picker opens outside the text editor toolbar and stays open until closed or another toolbar action is used.
 - Reused built-in `type` icon for Text Box widget; removed unused file.
+- Text Box widget markup now uses a `<div><p><span></span></p></div>` structure
+  so inline edits can target individual spans.
 - Text widgets now enter editing mode only on double-click, preventing
   accidental drags while typing.
 - Widget containers disable text selection during drag; editing mode re-enables


### PR DESCRIPTION
## Summary
- refine Text Box widget markup with nested `<p><span>`
- adjust Text Box widget SCSS to remove paragraph margin
- document the new structure in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68557d60e4a4832897e625a1cb8f314d