### PR TITLE
Add decimal font size support

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -95,7 +95,7 @@ async function init() {
         '<button type="button" class="tb-btn fs-dec">-</button>' +
         '<div class="fs-dropdown">' +
           '<button type="button" class="fs-btn"><span>' +
-            '<input type="number" class="fs-input" value="16" min="8" />' +
+            '<input type="number" class="fs-input" value="16" min="1" max="800" step="0.1" pattern="\\d*" tabindex="-1" placeholder="--" />' +
           '</span></button>' +
           '<div class="fs-options">' +
             [12,14,16,18,24,36].map(s => `<span data-size="${s}">${s}</span>`).join('') +
@@ -231,7 +231,7 @@ async function init() {
       activeEl.focus();
     };
     const applySize = size => {
-      const val = parseInt(size, 10);
+      const val = parseFloat(size);
       if (!val) return;
       fsInput.value = val;
       if (!activeEl) return;
@@ -326,10 +326,10 @@ async function init() {
       activeEl.focus();
     };
     toolbar.querySelector('.fs-inc').addEventListener('click', () => {
-      applySize((parseInt(fsInput.value, 10) || 16) + 1);
+      applySize((parseFloat(fsInput.value) || 16) + 1);
     });
     toolbar.querySelector('.fs-dec').addEventListener('click', () => {
-      applySize((parseInt(fsInput.value, 10) || 16) - 1);
+      applySize((parseFloat(fsInput.value) || 16) - 1);
     });
     const filterOptions = val => {
       fsOptions.querySelectorAll('span[data-size]').forEach(span => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- Font size input now supports decimal values up to 800 for precise control.
 - Widgets stay locked until clicking outside; edit mode now opens on a second
   click of the selected widget instead of a double-click.
 - Simplified widget locking: text edit mode now locks widgets directly and


### PR DESCRIPTION
## Summary
- allow decimal values in toolbar font size input
- parse font size as float
- document the improvement in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68557e594e908328aa572daae5088285