### PR TITLE
Implement hit-layer editing safeguard

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textBoxWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textBoxWidget.js
@@ -11,8 +11,25 @@ export function render(el) {
   p.appendChild(span);
   wrapper.appendChild(p);
 
+  /* NEW ­–––––––––––––––––––––––––––––––––––––––––  
+     Hit-Layer verhindert ungewolltes Editieren
+  ------------------------------------------------*/
+  const shield = document.createElement('div');
+  shield.className = 'hit-layer';
+  Object.assign(shield.style, {
+    position: 'absolute',
+    inset: '0',
+    background: 'transparent',
+    cursor: 'move',
+    pointerEvents: 'auto',
+    zIndex: '5'
+  });
+  wrapper.style.position = 'relative';
+  wrapper.appendChild(shield);
+
   el.innerHTML = '';
   el.appendChild(wrapper);
 
+  // registriere das <span>, nicht den ganzen <p>
   registerElement(span);
 }

--- a/BlogposterCMS/public/assets/scss/site.scss
+++ b/BlogposterCMS/public/assets/scss/site.scss
@@ -33,3 +33,7 @@
 @import 'pages/users';
 @import 'pages/permissions';
 @import 'pages/widgets';
+
+.hit-layer { pointer-events: auto; }
+
+.canvas-item.editing { z-index: 9999; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 El Psy Kongroo
 
+## [Unreleased]
+### Added
+- Hit-layer overlay for text widgets to prevent accidental edits while dragging.
+### Fixed
+- Builder grid reference exposed for text editor to properly lock widgets.
+- Toolbar context restored when editing text widgets and content now sanitized on save.
+- Removed duplicate toolbar helper definitions and cleaned unused variables in the editor.
+
 ## [0.6.0] – 2025-06-21
 ### Core Rewrite
 - CanvasGrid replaces GridStack with a fully custom drag-and-drop builder using GPU-accelerated transforms.


### PR DESCRIPTION
## Summary
- add a transparent hit-layer to textbox widgets
- add toolbar helpers and rewrite `editElement` to manage hit-layer and locking
- create hit-layer when rendering widgets and simplify double-click editing
- clean up obsolete widget lock listener
- tweak styles and document change in changelog
- expose builder grid via `__grid` for text editor
- reorganize toolbar helper placement
- restore toolbar context and sanitize HTML on save
- remove duplicate toolbar helpers and unused variables

## Testing
- `npm test --prefix BlogposterCMS`


------
https://chatgpt.com/codex/tasks/task_e_685671a9c83083289d91e18ffa3fb3fc