### PR TITLE
Implement two-step text editing

### DIFF
--- a/BlogposterCMS/public/assets/js/canvasGrid.js
+++ b/BlogposterCMS/public/assets/js/canvasGrid.js
@@ -299,12 +299,11 @@ export class CanvasGrid {
 
   _updateBBox() {
     if (!this.activeEl || this.staticGrid) return;
-    const locked = this.activeEl.getAttribute('gs-locked') === 'true';
     const noResize = this.activeEl.getAttribute('gs-no-resize') === 'true';
     const noMove = this.activeEl.getAttribute('gs-no-move') === 'true';
-    const hide = locked || noResize || noMove;
-    this.bbox.classList.toggle('disabled', hide);
-    if (hide) return;
+    const disabled = noResize && noMove;
+    this.bbox.classList.toggle('disabled', disabled);
+    if (disabled) return;
     const rect = this.activeEl.getBoundingClientRect();
     const gridRect = this.el.getBoundingClientRect();
     const transform = this.activeEl.style.transform;
@@ -317,11 +316,14 @@ export class CanvasGrid {
   }
 
   select(el) {
+    if (this.activeEl) this.activeEl.classList.remove('selected');
     this.activeEl = el;
+    if (el) el.classList.add('selected');
     this._updateBBox();
   }
 
   clearSelection() {
+    if (this.activeEl) this.activeEl.classList.remove('selected');
     this.activeEl = null;
     this.bbox.style.display = 'none';
   }

--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -385,10 +385,15 @@ export function editElement(el, onSave) {
   widget.classList.add('editing');
 
   widget.setAttribute('gs-locked', 'true');
-  widget.closest('.canvas-grid')?.__grid
-        ?.update(widget, { locked: true, noMove: true, noResize: true });
+  const grid = widget.closest('.canvas-grid')?.__grid;
+  grid?.update(widget, { locked: true, noMove: true, noResize: false });
 
   widget.querySelector('.hit-layer')?.remove();
+
+  const block  = () => grid?.update(widget, { noMove: true });
+  const allow  = () => grid?.update(widget, { noMove: false });
+  el.addEventListener('mouseenter', block);
+  el.addEventListener('mouseleave', allow);
 
   el.setAttribute('contenteditable', 'true');
   el.focus();
@@ -409,8 +414,10 @@ export function editElement(el, onSave) {
     widget.dataset.layer = prevLayer;
     widget.style.zIndex = String(prevLayer);
     widget.setAttribute('gs-locked', 'false');
-    widget.closest('.canvas-grid')?.__grid
-          ?.update(widget, { locked: false, noMove: false, noResize: false });
+    grid?.update(widget, { locked: false, noMove: false, noResize: false });
+
+    el.removeEventListener('mouseenter', block);
+    el.removeEventListener('mouseleave', allow);
 
     if (!widget.querySelector('.hit-layer')) {
       const h = document.createElement('div');
@@ -444,11 +451,13 @@ export function enableAutoEdit() {
     if (toolbar && toolbar.contains(ev.target)) return;
     const el = findEditableFromEvent(ev);
     if (!el) return;
+    const widget = el.closest('.canvas-item');
+    if (!widget || !widget.classList.contains('selected')) return;
     ev.stopPropagation();
     ev.preventDefault();
     editElement(el, el.__onSave);
   };
-  document.addEventListener('dblclick', autoHandler, true);
+  document.addEventListener('click', autoHandler, true);
 }
 
 function showToolbar(el) {

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -503,3 +503,7 @@ body.preview-desktop #content {
 .bounding-box.disabled {
   display: none;
 }
+
+.hit-layer { pointer-events:auto; }
+.canvas-item.selected .hit-layer { pointer-events:none; }
+.canvas-item:not(.selected) .hit-layer { pointer-events:auto; }

--- a/BlogposterCMS/public/assets/scss/site.scss
+++ b/BlogposterCMS/public/assets/scss/site.scss
@@ -34,6 +34,4 @@
 @import 'pages/permissions';
 @import 'pages/widgets';
 
-.hit-layer { pointer-events: auto; }
-
 .canvas-item.editing { z-index: 9999; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ El Psy Kongroo
 ## [Unreleased]
 ### Changed
 - Consolidated page editor widgets into a single `pageEditorWidget` and added save action to the content header.
+- Hit-layer rules consolidated in `_builder.scss` only
 ### Added
 - Hit-layer overlay for text widgets to prevent accidental edits while dragging.
+- Canva-style two-step editing with click-to-edit and persistent bounding box.
 ### Fixed
 - Builder grid reference exposed for text editor to properly lock widgets.
 - Toolbar context restored when editing text widgets and content now sanitized on save.


### PR DESCRIPTION
## Summary
- document hit-layer rule source in CHANGELOG

## Testing
- `npm --prefix BlogposterCMS test --silent`
- `npm --prefix BlogposterCMS run build` *(fails to affect CSS due to missing Sass)*

------
https://chatgpt.com/codex/tasks/task_e_68569672e72c8328af7c62cdfa9b1f86