### PR TITLE
Fix widget selection and hit layer

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -1094,6 +1094,10 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
   }
 
   function attachLockOnClick(el) {
+    el.addEventListener('click', e => {
+      e.stopPropagation();
+      selectWidget(el);
+    });
     el.addEventListener('dblclick', e => {
       const editable = el.querySelector('span[contenteditable], span') ||
                        el.querySelector('[data-editable]');

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -505,7 +505,8 @@ body.preview-desktop #content {
 }
 
 .hit-layer {
-  pointer-events: none;   /* Klicks endlich durchlassen */
+  pointer-events: auto;   /* Klicks endlich durchlassen */
 }
 
+.canvas-item.selected .hit-layer { pointer-events: none; }
 .canvas-item.editing { z-index: 9999; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ El Psy Kongroo
 ## [Unreleased]
 ### Changed
 - Hit-layer overlay no longer intercepts clicks in the builder.
+- Click on a widget now selects it and displays the action bar.
 - Action bar now reappears when widgets move or resize.
 - Consolidated page editor widgets into a single `pageEditorWidget` and added save action to the content header.
 - Hit-layer rules consolidated in `_builder.scss` only


### PR DESCRIPTION
## Summary
- prevent hit-layer from blocking clicks once widget selected
- add single-click handler so clicking a widget selects it and shows the action bar
- document behaviour change in changelog

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856a70b9e808328941985f09b188e0d