### PR TITLE
Fix builder layer defaults

### DIFF
--- a/BlogposterCMS/public/assets/js/pageRenderer.js
+++ b/BlogposterCMS/public/assets/js/pageRenderer.js
@@ -333,8 +333,10 @@ function ensureLayout(layout = {}, lane = 'public') {
       // Pass page IDs as strings so MongoDB ObjectIds remain intact. Postgres
       // will cast numeric strings automatically.
       const pageIdParam = urlParams.get('pageId') || null;
+      const startLayerParam = parseInt(urlParams.get('layer'), 10);
+      const startLayer = Number.isFinite(startLayerParam) ? startLayerParam : 0;
 
-      await initBuilder(sidebarEl, contentEl, pageIdParam);
+      await initBuilder(sidebarEl, contentEl, pageIdParam, startLayer);
 
       enableAutoEdit();
 

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -17,7 +17,7 @@ function addHitLayer(widget) {
   widget.appendChild(shield);
 }
 
-export async function initBuilder(sidebarEl, contentEl, pageId = null) {
+export async function initBuilder(sidebarEl, contentEl, pageId = null, startLayer = 0) {
   document.body.classList.add('builder-mode');
   // Builder widgets load the active theme inside their shadow roots.
   // Inject the theme scoped to the builder grid so the preview matches
@@ -59,7 +59,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
     { name: 'Layer 1', layout: [] },
     { name: 'Layer 2', layout: [] }
   ];
-  let activeLayer = 0;
+  let activeLayer = Math.max(0, Math.min(layoutLayers.length - 1, Number(startLayer) || 0));
   let globalLayoutName = null;
   let layoutBar;
   let globalToggle;
@@ -1107,7 +1107,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null) {
 
 
   layoutLayers[0].layout = initialLayout;
-  applyCompositeLayout(0);
+  applyCompositeLayout(activeLayer);
   pushState(initialLayout);
 
   gridEl.addEventListener('dragover',  e => { e.preventDefault(); gridEl.classList.add('drag-over'); });

--- a/BlogposterCMS/public/assets/plainspace/admin/defaultwidgets/pageList.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/defaultwidgets/pageList.js
@@ -296,7 +296,7 @@ async function editPage(id) {
 }
 
 async function editLayout(id) {
-  window.location.href = `/admin/builder?pageId=${id}`;
+  window.location.href = `/admin/builder?pageId=${id}&layer=1`;
 }
 
 async function toggleDraft(page) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ El Psy Kongroo
 - Action bar now reappears when widgets move or resize.
 - Consolidated page editor widgets into a single `pageEditorWidget` and added save action to the content header.
 - Hit-layer rules consolidated in `_builder.scss` only
+- Builder opens page layouts on Layer 1 by default while keeping the global layer accessible.
 ### Added
 - Hit-layer overlay for text widgets to prevent accidental edits while dragging.
 - Canva-style two-step editing with click-to-edit and persistent bounding box.


### PR DESCRIPTION
## Summary
- switch page builder link to explicitly use layer 1
- parse layer from query params when entering builder
- initialize builder with provided start layer
- update changelog

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_6856aa7c02988328bd9bd6db13fdd895