### PR TITLE
Fix global text editor init in builder mode

### DIFF
--- a/BlogposterCMS/public/assets/js/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/js/globalTextEditor.js
@@ -471,6 +471,11 @@ export function enableAutoEdit() {
   document.addEventListener('click', autoHandler, true);
 }
 
+export async function initTextEditor() {
+  await init().catch(err => console.error('[globalTextEditor] init failed', err));
+  enableAutoEdit();
+}
+
 function showToolbar(el) {
   if (!toolbar) return;
   toolbar.style.display = 'flex';
@@ -488,6 +493,5 @@ function hideToolbar() {
 }
 
 if (document.body.classList.contains('builder-mode')) {
-  init().catch(err => console.error('[globalTextEditor] init failed', err));
-  enableAutoEdit();
+  initTextEditor();
 }

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -1,6 +1,6 @@
 // public/assets/plainspace/admin/builderRenderer.js
 import { init as initCanvasGrid } from '../../js/canvasGrid.js';
-import { editElement } from '../../js/globalTextEditor.js';
+import { editElement, initTextEditor } from '../../js/globalTextEditor.js';
 
 function addHitLayer(widget) {
   const shield = document.createElement('div');
@@ -19,6 +19,7 @@ function addHitLayer(widget) {
 
 export async function initBuilder(sidebarEl, contentEl, pageId = null, startLayer = 0) {
   document.body.classList.add('builder-mode');
+  initTextEditor();
   // Builder widgets load the active theme inside their shadow roots.
   // Inject the theme scoped to the builder grid so the preview matches
   // the active theme without altering the surrounding UI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ El Psy Kongroo
 - Toolbar context restored when editing text widgets and content now sanitized on save.
 - Removed duplicate toolbar helper definitions and cleaned unused variables in the editor.
 - Text widgets remain editable until clicking outside the widget or toolbar and no longer lock movement.
+- Global text editor now initializes correctly when the builder loads, fixing missing toolbar issues.
 
 ## [0.6.0] – 2025-06-21
 ### Core Rewrite


### PR DESCRIPTION
## Summary
- export `initTextEditor` from the global text editor and call it when needed
- invoke `initTextEditor` after the builder activates builder-mode
- document the fix in the changelog

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_6856afceddb08328be23c23048929487