### PR TITLE
Fix builder toolbar click handler

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -737,8 +737,12 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null, startLaye
 
   document.addEventListener('click', e => {
     if (!activeWidgetEl) return;
-    if (e.target.closest('.canvas-item') === activeWidgetEl ||
-        e.target.closest('.widget-action-bar')) {
+    if (
+      e.target.closest('.canvas-item') === activeWidgetEl ||
+      e.target.closest('.widget-action-bar') ||
+      e.target.closest('.text-editor-toolbar') ||
+      e.target.closest('.color-picker')
+    ) {
       return;
     }
     actionBar.style.display = 'none';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ El Psy Kongroo
 - Removed duplicate toolbar helper definitions and cleaned unused variables in the editor.
 - Text widgets remain editable until clicking outside the widget or toolbar and no longer lock movement.
 - Global text editor now initializes correctly when the builder loads, fixing missing toolbar issues.
+- Toolbar buttons and color picker no longer close the widget while editing.
 
 ## [0.6.0] – 2025-06-21
 ### Core Rewrite


### PR DESCRIPTION
## Summary
- keep widget toolbar open when clicking toolbar buttons or color picker
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856baa0a9f48328b742da0f58e10978