### PR TITLE
Implement MutationObserver sync for builder

### DIFF
--- a/BlogposterCMS/package-lock.json
+++ b/BlogposterCMS/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "blogposter_cms",
-    "version": "0.5.5",
+    "version": "0.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "blogposter_cms",
-            "version": "0.5.5",
+            "version": "0.6.0",
             "dependencies": {
                 "@rc-component/color-picker": "^2.0.1",
                 "axios": "^1.7.7",

--- a/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/admin/builderRenderer.js
@@ -213,14 +213,27 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null, startLaye
     target.style.userSelect = 'text';
     let obs = userObservers.get(widget);
     if (obs) obs.disconnect();
+    const instId = widget.dataset.instanceId;
     obs = new MutationObserver(() => {
+      const html = target.innerHTML;
       const htmlField = widget.__codeEditor?.querySelector('.editor-html');
-      if (htmlField) htmlField.value = container.innerHTML;
+      if (htmlField) htmlField.value = html;
+      if (instId) {
+        codeMap[instId] = codeMap[instId] || {};
+        codeMap[instId].html = html;
+        if (pageId) scheduleAutosave();
+      }
     });
     obs.observe(target, { childList: true, subtree: true, characterData: true });
     target.addEventListener('input', () => {
+      const html = target.innerHTML;
       const htmlField = widget.__codeEditor?.querySelector('.editor-html');
-      if (htmlField) htmlField.value = target.innerHTML;
+      if (htmlField) htmlField.value = html;
+      if (instId) {
+        codeMap[instId] = codeMap[instId] || {};
+        codeMap[instId].html = html;
+        if (pageId) scheduleAutosave();
+      }
     });
     userObservers.set(widget, obs);
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ El Psy Kongroo
 ### Added
 - Hit-layer overlay for text widgets to prevent accidental edits while dragging.
 - Canva-style two-step editing with click-to-edit and persistent bounding box.
+- DOM mutation tracking keeps widget code synchronized and triggers autosave.
 ### Fixed
 - Builder grid reference exposed for text editor to properly lock widgets.
 - Toolbar context restored when editing text widgets and content now sanitized on save.
@@ -22,6 +23,7 @@ El Psy Kongroo
 - Text widgets remain editable until clicking outside the widget or toolbar and no longer lock movement.
 - Global text editor now initializes correctly when the builder loads, fixing missing toolbar issues.
 - Toolbar buttons and color picker no longer close the widget while editing.
+- DOM mutation tracking now records the actual editable section so nested edits persist correctly.
 
 ## [0.6.0] – 2025-06-21
 ### Core Rewrite


### PR DESCRIPTION
## Summary
- sync in-place widget edits using MutationObserver
- document DOM tracking change in changelog
- fix observer to track exact editable element

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856eb0ceab48328b60da8ba2162da3c