### PR TITLE
Refactor plainspace scripts

### DIFF
--- a/BlogposterCMS/app.js
+++ b/BlogposterCMS/app.js
@@ -548,7 +548,7 @@ app.get('/admin/home', pageLimiter, csrfProtection, async (req, res) => {
         let html = fs.readFileSync(path.join(publicPath, 'admin.html'), 'utf8');
         if (renderMode === 'server') {
           html = html.replace(
-            /<script type="module" src="\/assets\/js\/pageRenderer.js"><\/script>\s*/i,
+            /<script type="module" src="\/assets\/plainspace\/main\/pageRenderer.js"><\/script>\s*/i,
             ''
           );
         }
@@ -658,7 +658,7 @@ app.get('/admin/*', pageLimiter, csrfProtection, async (req, res, next) => {
     );
     if (renderMode === 'server') {
       html = html.replace(
-        /<script type="module" src="\/assets\/js\/pageRenderer.js"><\/script>\s*/i,
+        /<script type="module" src="\/assets\/plainspace\/main\/pageRenderer.js"><\/script>\s*/i,
         ''
       );
     }
@@ -965,7 +965,7 @@ app.get('/:slug?', pageLimiter, async (req, res, next) => {
     let html = fs.readFileSync(pageHtmlPath, 'utf8');
     if (renderMode === 'server') {
       html = html.replace(
-        /<script type="module" src="\/assets\/js\/pageRenderer.js"><\/script>\s*/i,
+        /<script type="module" src="\/assets\/plainspace\/main\/pageRenderer.js"><\/script>\s*/i,
         ''
       );
     }

--- a/BlogposterCMS/public/admin.html
+++ b/BlogposterCMS/public/admin.html
@@ -45,7 +45,7 @@
   <script src="/assets/js/icons.js"></script>
 
   <!-- 4) Generic page renderer (builds header, sidebar, widgets)    -->
-  <script type="module" src="/assets/js/pageRenderer.js"></script>
+  <script type="module" src="/assets/plainspace/main/pageRenderer.js"></script>
 
   <!-- Search functionality for admin top bar -->
   <script type="module" src="/assets/js/adminSearch.js"></script>

--- a/BlogposterCMS/public/assets/plainspace/main/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/plainspace/main/globalTextEditor.js
@@ -1,7 +1,7 @@
-// public/assets/js/globalTextEditor.js
+// public/assets/plainspace/main/globalTextEditor.js
 // Lightweight global text editor for builder mode.
-import { createColorPicker } from './colorPicker.js';
-import { isValidTag } from './allowedTags.js';
+import { createColorPicker } from '../../js/colorPicker.js';
+import { isValidTag } from '../../js/allowedTags.js';
 
 let toolbar = null;
 let activeEl = null;
@@ -490,6 +490,11 @@ export function editElement(el, onSave) {
 
 export function registerElement(editable, onSave) {
   if (!editable) return;
+  if (!editable.id || (document.getElementById(editable.id) && document.getElementById(editable.id) !== editable)) {
+    editable.id = `editable-${Math.random().toString(36).slice(2,8)}`;
+  }
+  if (editable.__registered) return;
+  editable.__registered = true;
   editable.__onSave = onSave;
   const widget = findWidget(editable);
   if (widget) {

--- a/BlogposterCMS/public/assets/plainspace/main/pageRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/main/pageRenderer.js
@@ -1,8 +1,8 @@
-// public/assets/js/pageRenderer.js
+// public/assets/plainspace/main/pageRenderer.js
 
-import { fetchPartial } from '../plainspace/admin/fetchPartial.js';
-import { initBuilder } from '../plainspace/admin/builderRenderer.js';
-import { init as initCanvasGrid } from './canvasGrid.js';
+import { fetchPartial } from '../admin/fetchPartial.js';
+import { initBuilder } from '../admin/builderRenderer.js';
+import { init as initCanvasGrid } from '../../js/canvasGrid.js';
 import { enableAutoEdit, sanitizeHtml } from './globalTextEditor.js';
 
 // Default rows for admin widgets (~50px with 5px grid cells)

--- a/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textBoxWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/public/basicwidgets/textBoxWidget.js
@@ -1,5 +1,5 @@
 //public/assets/plainspace/public/basicwidgets/textBoxWidget.js
-import { registerElement } from '../../../js/globalTextEditor.js';
+import { registerElement } from '../../main/globalTextEditor.js';
 
 export function render(el, ctx = {}) {
   if (!el) return;
@@ -12,7 +12,6 @@ export function render(el, ctx = {}) {
 
   const editable = document.createElement('div');
   editable.className = 'editable';
-  editable.setAttribute('contenteditable', 'true');
   editable.textContent = 'Lorem ipsum dolor sit amet';
 
   if (ctx.id) {

--- a/BlogposterCMS/public/index.html
+++ b/BlogposterCMS/public/index.html
@@ -19,6 +19,6 @@
   <!-- global media explorer -->
   <script src="/assets/js/openExplorer.js"></script>
   <!-- Your pageRenderer, which now just calls miniEmitter(...) -->
-  <script type="module" src="/assets/js/pageRenderer.js"></script>
+  <script type="module" src="/assets/plainspace/main/pageRenderer.js"></script>
 </body>
 </html>

--- a/BlogposterCMS/webpack.config.js
+++ b/BlogposterCMS/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
     login: './public/assets/js/login.js',
     meltdownEmitter: './public/assets/js/meltdownEmitter.js',
     pageDataLoader: './public/assets/js/pageDataLoader.js',
-    pageRenderer: './public/assets/js/pageRenderer.js',
+    pageRenderer: './public/assets/plainspace/main/pageRenderer.js',
     
     install: './public/assets/js/install.js',
     sortable: './public/assets/js/sortable.min.js',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ El Psy Kongroo
 
 ## [Unreleased]
 ### Changed
+- Plainspace scripts consolidated under `public/assets/plainspace/main`.
+- Widgets no longer set `contenteditable`; `globalTextEditor` controls editing exclusively.
 - Hit-layer overlay no longer intercepts clicks in the builder.
 - Click on a widget now selects it and displays the action bar.
 - Action bar now reappears when widgets move or resize.


### PR DESCRIPTION
## Summary
- streamline text box widget so the editor sets `contenteditable`
- move plainspace core scripts under `public/assets/plainspace/main`
- update builder logic to rely on `globalTextEditor` for editing
- ensure editables get unique IDs on registration
- adjust script paths and webpack config
- document changes in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857d06b96b48328acdbcee078568a65