### PR TITLE
Fix partial path resolution

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/dashboard/fetchPartial.js
+++ b/BlogposterCMS/public/assets/plainspace/dashboard/fetchPartial.js
@@ -5,7 +5,7 @@
  */
 export async function fetchPartial(partialName, partialType = '') {
   const typePath = partialType ? `${partialType}/` : '';
-  const url = `/assets/plainspace/partials/${partialName}.html`;
+  const url = `/assets/plainspace/partials/${typePath}${partialName}.html`;
   const resp = await window.fetchWithTimeout(url);
   if (!resp.ok) {
     throw new Error(`HTTP ${resp.status} while fetching ${url}`);

--- a/BlogposterCMS/public/assets/plainspace/dashboard/utils.js
+++ b/BlogposterCMS/public/assets/plainspace/dashboard/utils.js
@@ -1,9 +1,11 @@
 // public/assets/plainspace/dashboard/utils.js
 async function fetchPartial(partialName, partialType = 'headers') {
-  const response = await window.fetchWithTimeout(`/assets/partials/${partialType}/${partialName}.html`);
-    if (!response.ok) {
-      throw new Error(`Partial "${partialName}" (${partialType}) not found.`);
-    }
-    return await response.text();
+  const response = await window.fetchWithTimeout(
+    `/assets/plainspace/partials/${partialType}/${partialName}.html`
+  );
+  if (!response.ok) {
+    throw new Error(`Partial "${partialName}" (${partialType}) not found.`);
   }
+  return await response.text();
+}
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ El Psy Kongroo
 - Global text editor now initializes correctly when the builder loads, fixing missing toolbar issues.
 - Toolbar buttons and color picker no longer close the widget while editing.
 - DOM mutation tracking now records the actual editable section so nested edits persist correctly.
+- Fixed partial loading paths in dashboard utilities after file restructure.
 - fixed path to `fetchPartial.js` in `pageRenderer.js` after asset reorganization
 - removed stray closing brace from `builderRenderer.js` to resolve build errors
 


### PR DESCRIPTION
## Summary
- correct partial paths in dashboard utilities
- include optional partial type in `fetchPartial`
- note path fix in changelog

## Testing
- `npm test --silent --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_6857e4686af48328849464e271f0f998