### PR TITLE
Fix textBoxWidget import path

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/widgets/public/basicwidgets/textBoxWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/widgets/public/basicwidgets/textBoxWidget.js
@@ -1,5 +1,5 @@
 // public/assets/plainspace/widgets/public/basicwidgets/textBoxWidget.js
-import { registerElement } from '../../main/globalTextEditor.js';
+import { registerElement } from '../../../main/globalTextEditor.js';
 
 export function render(el, ctx = {}) {
   if (!el) return;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ El Psy Kongroo
 - Fixed partial loading paths in dashboard utilities after file restructure.
 - fixed path to `fetchPartial.js` in `pageRenderer.js` after asset reorganization
 - removed stray closing brace from `builderRenderer.js` to resolve build errors
+- fixed path to `globalTextEditor.js` in `textBoxWidget` so widget loads correctly
 
 ## [0.6.0] – 2025-06-21
 ### Core Rewrite


### PR DESCRIPTION
## Summary
- resolve widget import path for globalTextEditor
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858008c9c088328bae391293b8c2591