### PR TITLE
Fix autosave grid race condition

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
@@ -158,7 +158,14 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null, startLaye
   contentEl.innerHTML = `<div id="builderGrid" class="canvas-grid builder-grid"></div>`;
   gridEl = document.getElementById('builderGrid');
   const { updateAllWidgetContents } = registerBuilderEvents(gridEl, ensureCodeMap(), { getRegisteredEditable });
-  const saveLayoutCtx = { updateAllWidgetContents, getCurrentLayout, pushState, meltdownEmit, pageId, codeMap: ensureCodeMap() };
+  const saveLayoutCtx = {
+    updateAllWidgetContents,
+    getCurrentLayout: () => getCurrentLayout(gridEl, ensureCodeMap()),
+    pushState,
+    meltdownEmit,
+    pageId,
+    codeMap: ensureCodeMap()
+  };
   await applyBuilderTheme();
   // Allow overlapping widgets for layered layouts
   const grid = initGrid(gridEl, state, selectWidget);

--- a/BlogposterCMS/public/assets/plainspace/builder/managers/gridManager.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/managers/gridManager.js
@@ -11,6 +11,7 @@ export function initGrid(gridEl, state, selectWidget) {
 }
 
 export function getCurrentLayout(gridEl, codeMap) {
+  if (!gridEl) return [];
   const items = Array.from(gridEl.querySelectorAll('.canvas-item'));
   return items.map(el => ({
     id: el.dataset.instanceId,
@@ -26,6 +27,7 @@ export function getCurrentLayout(gridEl, codeMap) {
 }
 
 export function getCurrentLayoutForLayer(gridEl, idx, codeMap) {
+  if (!gridEl) return [];
   const items = Array.from(gridEl.querySelectorAll(`.canvas-item[data-layer="${idx}"]`));
   return items.map(el => ({
     id: el.dataset.instanceId,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ El Psy Kongroo
 ## [Unreleased]
 - fixed crash when adding widgets to the builder grid due to missing options passed to attachOptionsMenu
 - ensured existing `codeMap` is passed when creating widgets
+- prevented autosave crash when layout grid was not ready by validating the grid element
 
 ### Changed
 - modularized builderRenderer into dedicated managers (grid, widget, layout, event)


### PR DESCRIPTION
## Summary
- avoid crashes when autosave runs before the builder grid is available
- handle missing grid element defensively
- document autosave fix in changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858035e02c8832885b504b2da345583