### PR TITLE
Fix sanitizeHtml to preserve allowed styles

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/main/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/plainspace/main/globalTextEditor.js
@@ -19,7 +19,40 @@ export function sanitizeHtml(html) {
   div.querySelectorAll('script, style').forEach(el => el.remove());
   div.querySelectorAll('*').forEach(el => {
     [...el.attributes].forEach(attr => {
-      if (/^on/i.test(attr.name)) el.removeAttribute(attr.name);
+      const name = attr.name.toLowerCase();
+      if (name.startsWith('on')) {
+        el.removeAttribute(attr.name);
+      } else if (name === 'style') {
+        const allowed = [
+          'font-size',
+          'font-family',
+          'text-decoration',
+          'font-weight',
+          'color',
+          'background-color'
+        ];
+        const sanitized = attr.value
+          .split(';')
+          .map(s => s.trim())
+          .filter(Boolean)
+          .map(s => {
+            const [prop, value] = s.split(':').map(p => p.trim());
+            if (
+              allowed.includes(prop.toLowerCase()) &&
+              !/(expression|url\(|javascript)/i.test(value)
+            ) {
+              return `${prop}:${value}`;
+            }
+            return null;
+          })
+          .filter(Boolean)
+          .join('; ');
+        if (sanitized) {
+          el.setAttribute('style', sanitized);
+        } else {
+          el.removeAttribute('style');
+        }
+      }
     });
   });
   return div.innerHTML;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ El Psy Kongroo
 - Canva-style two-step editing with click-to-edit and persistent bounding box.
 - DOM mutation tracking keeps widget code synchronized and triggers autosave.
 ### Fixed
+- inline styles like `font-size` and `color` are now preserved when saving text
+  widgets, while disallowed style properties are stripped during sanitization
 - Builder grid reference exposed for text editor to properly lock widgets.
 - Toolbar context restored when editing text widgets and content now sanitized on save.
 - Removed duplicate toolbar helper definitions and cleaned unused variables in the editor.


### PR DESCRIPTION
## Summary
- sanitizeHtml no longer strips allowed inline styles such as font-size, font-weight, color and others
- document sanitization update in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858061e2238832882342b9443736bee