### PR TITLE
Fix sync of loaded text widgets

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/widgets/widgetRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/widgets/widgetRenderer.js
@@ -1,5 +1,6 @@
 //public/assets/plainspace/builder/widgets/widgetRenderer.js
 import { addHitLayer, executeJs } from '../utils.js';
+import { registerElement } from '../main/globalTextEditor.js';
 
 export function renderWidget(wrapper, widgetDef, codeMap, customData = null) {
   const instanceId = wrapper.dataset.instanceId;
@@ -36,7 +37,13 @@ export function renderWidget(wrapper, widgetDef, codeMap, customData = null) {
       customStyle.textContent = data.css;
       root.appendChild(customStyle);
     }
-    if (data.html) container.innerHTML = data.html;
+    if (data.html) {
+      container.innerHTML = data.html;
+      container.querySelectorAll('.editable').forEach(el => {
+        registerElement(el);
+        console.log('[DEBUG] registered editable in loaded widget', el);
+      });
+    }
     if (data.js) {
       try { executeJs(data.js, wrapper, root); } catch (e) { console.error('[Builder] custom js error', e); }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ El Psy Kongroo
 - builder renderer split into multiple modules under `public/assets/plainspace/builder`
   for easier maintenance; main entry renamed to `builderRenderer.js`
 ### Fixed
+- text widgets loaded from saved layouts now sync inline style changes to `codeMap` and log updates for easier debugging
 - removed outdated webpack entry for `alpine.js` to restore build
 - removed leftover widget helper functions from `builderRenderer.js` and resolved build error
 - fixed header and sidebar partial paths in `pageRenderer.js` so assets load correctly


### PR DESCRIPTION
## Summary
- sync inline style changes from loaded widgets to code map via `widgetHtmlUpdate`
- register editable nodes when loading widget HTML
- add debug logs for easier tracing
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858693f42ec8328abb9e8c4b011fa83