### PR TITLE
Implement caret positioning for text widget editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ El Psy Kongroo
 - fixed crash when adding widgets to the builder grid due to missing options passed to attachOptionsMenu
 - ensured existing `codeMap` is passed when creating widgets
 - prevented autosave crash when layout grid was not ready by validating the grid element
+- improved text widget editing to require a second click before entering edit mode and position the caret at the click location
 
 ### Changed
 - modularized builderRenderer into dedicated managers (grid, widget, layout, event)


### PR DESCRIPTION
## Summary
- let text widget editing start on a second click
- place the caret at the user click position when editing starts
- note behaviour change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68586f8b606483288477fc3eb633818b