### PR TITLE
Improve text editing flow

### DIFF
--- a/BlogposterCMS/package.json
+++ b/BlogposterCMS/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blogposter_cms",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "main": "app.js",
     "scripts": {
         "start": "node app.js",

--- a/BlogposterCMS/public/assets/plainspace/main/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/plainspace/main/globalTextEditor.js
@@ -499,10 +499,10 @@ export function editElement(el, onSave, clickEvent = null) {
   widget.style.zIndex = '9999';
   widget.classList.add('editing');
 
-  // Only disable dragging while editing but keep widget unlocked
+  // Keep widget draggable while editing and unlock it
   widget.setAttribute('gs-locked', 'false');
   const grid = widget.closest('.canvas-grid')?.__grid;
-  grid?.update(widget, { locked: false, noMove: true, noResize: false });
+  grid?.update(widget, { locked: false, noMove: false, noResize: false });
 
   if (hitLayer) hitLayer.style.pointerEvents = 'none';
 
@@ -600,7 +600,13 @@ export function enableAutoEdit() {
     const editable = getRegisteredEditable(widget) || el;
     ev.stopPropagation();
     ev.preventDefault();
-    editElement(editable, editable.__onSave, ev);
+
+    if (editable.getAttribute('contenteditable') === 'true') {
+      setCaretFromEvent(editable, ev);
+      editable.focus();
+    } else {
+      editElement(editable, editable.__onSave);
+    }
   };
   document.addEventListener('click', autoHandler, true);
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- global text editor activates on first click and keeps widgets draggable; a second click sets the caret at the exact position using `caretRangeFromPoint`
 - fixed crash when adding widgets to the builder grid due to missing options passed to attachOptionsMenu
 - ensured existing `codeMap` is passed when creating widgets
 - prevented autosave crash when layout grid was not ready by validating the grid element


### PR DESCRIPTION
## Summary
- activate text blocks with a single click
- keep widgets draggable while editing
- position caret precisely on the second click
- bump version to 0.6.1

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858ec15b87c8328a580623185c23bb6