### PR TITLE
Improve text widget click-to-edit

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/main/globalTextEditor.js
+++ b/BlogposterCMS/public/assets/plainspace/main/globalTextEditor.js
@@ -593,14 +593,16 @@ export function enableAutoEdit() {
   autoHandler = ev => {
     if (!document.body.classList.contains('builder-mode')) return;
     if (toolbar && toolbar.contains(ev.target)) return;
-    const el = findEditableFromEvent(ev);
-    if (!el) return;
-    const widget = findWidget(el);
+    const widget = findWidget(ev.target);
     if (!widget || !widget.classList.contains('selected')) return;
-    const editable = getRegisteredEditable(widget) || el;
+    let el = findEditableFromEvent(ev);
+    if (!el) {
+      el = getRegisteredEditable(widget);
+    }
+    if (!el) return;
     ev.stopPropagation();
     ev.preventDefault();
-    editElement(editable, editable.__onSave, ev);
+    editElement(el, el.__onSave, ev);
   };
   document.addEventListener('click', autoHandler, true);
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ El Psy Kongroo
 - ensured existing `codeMap` is passed when creating widgets
 - prevented autosave crash when layout grid was not ready by validating the grid element
 - improved text widget editing to require a second click before entering edit mode and position the caret at the click location
+- editing now begins when clicking anywhere on a selected widget, not just text elements
 
 ### Changed
 - modularized builderRenderer into dedicated managers (grid, widget, layout, event)


### PR DESCRIPTION
## Summary
- allow editing when clicking anywhere inside a selected widget
- document behavior change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858f129ef308328a4df1d6f11550141