### PR TITLE
Refactor editor modules

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
@@ -6,7 +6,7 @@ import {
   hideToolbar,
   setActiveElement,
   getRegisteredEditable
-} from '../main/globalTextEditor.js';
+} from '../editor/editor.js';
 import { initGrid, getCurrentLayout, getCurrentLayoutForLayer, pushState } from './managers/gridManager.js';
 import { applyLayout, getItemData } from './managers/layoutManager.js';
 import { registerDeselect } from './managers/eventManager.js';

--- a/BlogposterCMS/public/assets/plainspace/builder/widgets/widgetRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/widgets/widgetRenderer.js
@@ -1,6 +1,6 @@
 //public/assets/plainspace/builder/widgets/widgetRenderer.js
 import { addHitLayer, executeJs } from '../utils.js';
-import { registerElement } from '../../main/globalTextEditor.js';
+import { registerElement } from '../../editor/editor.js';
 
 export function renderWidget(wrapper, widgetDef, codeMap, customData = null) {
   const instanceId = wrapper.dataset.instanceId;

--- a/BlogposterCMS/public/assets/plainspace/editor/colorPicker.js
+++ b/BlogposterCMS/public/assets/plainspace/editor/colorPicker.js
@@ -1,4 +1,4 @@
-// public/assets/plainspace/builder/colorPicker.js
+// public/assets/plainspace/editor/colorPicker.js
 export function createColorPicker(options = {}) {
   const {
     presetColors = [
@@ -68,19 +68,21 @@ export function createColorPicker(options = {}) {
     addCustom.type = 'button';
     addCustom.className = 'color-circle add-custom';
     addCustom.textContent = '+';
-    const input = document.createElement('input');
-    input.type = 'color';
+    const input = document.createElement('div');
     input.className = 'color-input';
-    input.value = selectedColor;
-    input.addEventListener('input', ev => {
-      selectedColor = ev.target.value;
+    input.contentEditable = 'true';
+    input.textContent = selectedColor;
+    const sanitize = val => (/^#[0-9a-fA-F]{3,8}$/.test(val) ? val : selectedColor);
+    input.addEventListener('input', () => {
+      const val = sanitize(input.textContent.trim());
+      selectedColor = val;
       container.querySelectorAll('.color-circle').forEach(n => n.classList.remove('active'));
       addCustom.style.backgroundColor = selectedColor;
       addCustom.classList.add('active');
       onSelect(selectedColor);
     });
     addCustom.addEventListener('click', () => {
-      input.click();
+      input.focus();
     });
     section.appendChild(addCustom);
     section.appendChild(input);

--- a/BlogposterCMS/public/assets/plainspace/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/editor/editor.js
@@ -1,7 +1,7 @@
-// public/assets/plainspace/main/globalTextEditor.js
+// public/assets/plainspace/editor/editor.js
 // Lightweight global text editor for builder mode.
 import { isValidTag } from '../builder/allowedTags.js';
-import { createColorPicker } from '../builder/colorPicker.js';
+import { createColorPicker } from './colorPicker.js';
 
 let toolbar = null;
 let activeEl = null;

--- a/BlogposterCMS/public/assets/plainspace/main/pageRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/main/pageRenderer.js
@@ -3,7 +3,7 @@
 import { fetchPartial } from '../dashboard/fetchPartial.js';
 import { initBuilder } from '../builder/builderRenderer.js';
 import { init as initCanvasGrid } from './canvasGrid.js';
-import { enableAutoEdit, sanitizeHtml } from './globalTextEditor.js';
+import { enableAutoEdit, sanitizeHtml } from '../editor/editor.js';
 
 // Default rows for admin widgets (~50px with 5px grid cells)
 // Temporary patch: double the default height for larger widgets

--- a/BlogposterCMS/public/assets/plainspace/widgets/admin/userEditWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/widgets/admin/userEditWidget.js
@@ -1,4 +1,4 @@
-import { createColorPicker } from '../../builder/colorPicker.js';
+import { createColorPicker } from '../../editor/colorPicker.js';
 
 export async function render(el) {
   const meltdownEmit = window.meltdownEmit;

--- a/BlogposterCMS/public/assets/plainspace/widgets/public/basicwidgets/textBoxWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/widgets/public/basicwidgets/textBoxWidget.js
@@ -1,5 +1,5 @@
 // public/assets/plainspace/widgets/public/basicwidgets/textBoxWidget.js
-import { registerElement } from '../../../main/globalTextEditor.js';
+import { registerElement } from '../../../../editor/editor.js';
 
 export function render(el, ctx = {}) {
   if (!el) return;

--- a/BlogposterCMS/public/assets/scss/components/_color-picker.scss
+++ b/BlogposterCMS/public/assets/scss/components/_color-picker.scss
@@ -34,6 +34,15 @@
     color: #555;
   }
 
+  .color-input {
+    width: 60px;
+    padding: 2px 4px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 12px;
+    outline: none;
+  }
+
   .color-section-label {
     margin-right: 4px;
     font-size: 12px;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- moved `globalTextEditor` and `colorPicker` modules into a new `editor` folder and updated imports
 - restored self-made color picker using native color input and removed pickr library
 - removed custom color picker that intercepted clicks; built-in color inputs are now used for text and user color selection
 - fixed crash when adding widgets to the builder grid due to missing options passed to attachOptionsMenu


### PR DESCRIPTION
## Summary
- move global text editor and color picker under `editor`
- update imports to new folder
- make color picker editable with text input
- style `.color-input`
- document change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858f8e67af083288bd950c85c2c6450