### PR TITLE
Fix widget imports and icons

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
@@ -224,7 +224,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null, startLaye
     const current = undoStack.pop();
     redoStack.push(current);
     const prev = JSON.parse(undoStack[undoStack.length - 1]);
-    applyLayout(prev, { gridEl, grid, codeMap: ensureCodeMap(), allWidgets, layerIndex: activeLayer });
+    applyLayout(prev, { gridEl, grid, codeMap: ensureCodeMap(), allWidgets, layerIndex: activeLayer, iconMap: ICON_MAP });
     if (pageId && autosaveEnabled) scheduleAutosave();
   }
 
@@ -233,7 +233,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null, startLaye
     const next = redoStack.pop();
     undoStack.push(next);
     const layout = JSON.parse(next);
-    applyLayout(layout, { gridEl, grid, codeMap: ensureCodeMap(), allWidgets, layerIndex: activeLayer });
+    applyLayout(layout, { gridEl, grid, codeMap: ensureCodeMap(), allWidgets, layerIndex: activeLayer, iconMap: ICON_MAP });
     if (pageId && autosaveEnabled) scheduleAutosave();
   }
 
@@ -613,9 +613,9 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null, startLaye
   function applyCompositeLayout(idx) {
     gridEl.innerHTML = '';
     Object.keys(ensureCodeMap()).forEach(k => delete codeMap[k]);
-    applyLayout(layoutLayers[0].layout, { gridEl, grid, codeMap: ensureCodeMap(), allWidgets, append: false, layerIndex: 0 });
+    applyLayout(layoutLayers[0].layout, { gridEl, grid, codeMap: ensureCodeMap(), allWidgets, append: false, layerIndex: 0, iconMap: ICON_MAP });
     if (idx !== 0) {
-      applyLayout(layoutLayers[idx].layout, { gridEl, grid, codeMap: ensureCodeMap(), allWidgets, append: true, layerIndex: idx });
+      applyLayout(layoutLayers[idx].layout, { gridEl, grid, codeMap: ensureCodeMap(), allWidgets, append: true, layerIndex: idx, iconMap: ICON_MAP });
     }
   }
 

--- a/BlogposterCMS/public/assets/plainspace/builder/managers/layoutManager.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/managers/layoutManager.js
@@ -9,7 +9,8 @@ export function applyLayout(layout, {
   codeMap,
   allWidgets,
   layerIndex = 0,
-  append = false
+  append = false,
+  iconMap = {}
 } = {}) {
   const DEFAULT_ROWS = 20;
   if (!append) {
@@ -40,7 +41,7 @@ export function applyLayout(layout, {
     wrapper.setAttribute('gs-min-h', DEFAULT_ROWS);
     const content = document.createElement('div');
     content.className = 'canvas-item-content builder-themed';
-    content.innerHTML = `${getWidgetIcon(widgetDef)}<span>${widgetDef.metadata?.label || widgetDef.id}</span>`;
+    content.innerHTML = `${getWidgetIcon(widgetDef, iconMap)}<span>${widgetDef.metadata?.label || widgetDef.id}</span>`;
     wrapper.appendChild(content);
     attachRemoveButton(wrapper, grid, null, () => {});
     const editBtn = attachEditButton(wrapper, widgetDef, codeMap, null, () => {});

--- a/BlogposterCMS/public/assets/plainspace/widgets/public/basicwidgets/textBoxWidget.js
+++ b/BlogposterCMS/public/assets/plainspace/widgets/public/basicwidgets/textBoxWidget.js
@@ -1,5 +1,5 @@
 // public/assets/plainspace/widgets/public/basicwidgets/textBoxWidget.js
-import { registerElement } from '../../../../editor/editor.js';
+import { registerElement } from '../../../editor/editor.js';
 
 export function render(el, ctx = {}) {
   if (!el) return;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- fixed 404 errors when loading the Text Box widget by correcting import paths and icon mapping
 - moved `globalTextEditor` and `colorPicker` modules into a new `editor` folder and updated imports
 - restored self-made color picker using native color input and removed pickr library
 - removed custom color picker that intercepted clicks; built-in color inputs are now used for text and user color selection


### PR DESCRIPTION
## Summary
- fix wrong editor import in textBoxWidget.js
- ensure layout manager uses icon map when applying layouts
- pass icon map in builder renderer
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858fba06d348328bb9bf60f472112a2