### PR TITLE
Fix toolbar visibility and init text widgets

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -554,7 +554,11 @@ export function editElement(el, onSave, clickEvent = null) {
     if (hitLayer) hitLayer.style.pointerEvents = 'auto';
 
     widget.classList.remove('editing');
-    hideToolbar();
+    if (widget.classList.contains('selected')) {
+      showToolbar(widget);
+    } else {
+      hideToolbar();
+    }
     document.removeEventListener('mousedown', outsideClick, true);
   }
 
@@ -580,6 +584,9 @@ export function registerElement(editable, onSave) {
   }
   if (editable.__registered) return;
   editable.__registered = true;
+  if (!editable.hasAttribute('contenteditable')) {
+    editable.setAttribute('contenteditable', 'true');
+  }
   editable.__onSave = onSave;
   const widget = findWidget(editable);
   if (widget) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- toolbar stays visible after editing if the widget remains selected and loaded
+  text widgets now receive the `contenteditable` attribute automatically
 - fixed 404 errors when loading the Text Box widget by correcting import paths and icon mapping
 - moved `globalTextEditor` and `colorPicker` modules into a new `editor` folder and updated imports
 - restored self-made color picker using native color input and removed pickr library


### PR DESCRIPTION
## Summary
- keep text toolbar visible when exiting edit mode
- ensure loaded text widgets have `contenteditable` attribute
- document the change in the changelog

## Testing
- `npm test --silent --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_685901f8639c8328b2c0596a41d85f5c