### PR TITLE
Fix toolbar hide on first widget click

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -645,6 +645,8 @@ function hideToolbar() {
   }
 }
 
+document.addEventListener('widgetSelected', () => hideToolbar());
+
 export { showToolbar, hideToolbar };
 
 if (document.body.classList.contains('builder-mode')) {

--- a/BlogposterCMS/public/assets/plainspace/builder/renderer/actionBar.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/renderer/actionBar.js
@@ -31,6 +31,7 @@ export function createActionBar(selectWidget, grid, state, scheduleAutosave) {
     if (!el) return;
     if (state.activeWidgetEl) state.activeWidgetEl.classList.remove('selected');
     state.activeWidgetEl = el;
+    document.dispatchEvent(new Event('widgetSelected'));
     state.activeWidgetEl.classList.add('selected');
     grid.select(el);
     const locked = el.getAttribute('gs-locked') === 'true';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ El Psy Kongroo
 
 ## [Unreleased]
 - dispatchHtmlUpdate now triggered for every toolbar action to keep widget HTML synchronized
+- widgetSelected event now fires when selecting a widget so the editor can hide the toolbar on first click
 - toolbar stays visible after editing if the widget remains selected and loaded
   text widgets now receive the `contenteditable` attribute automatically
 - fixed 404 errors when loading the Text Box widget by correcting import paths and icon mapping


### PR DESCRIPTION
## Summary
- dispatch widgetSelected event when selecting widgets
- hide the toolbar on the first widget click via editor listener
- document change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68591267b24c83288c0aabd0e192c894