### PR TITLE
Fix text editor sanitization timing

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -27,7 +27,6 @@ function dispatchHtmlUpdate(el) {
 function updateAndDispatch(el) {
   if (!el) return;
   const clean = sanitizeHtml(el.innerHTML.trim());
-  el.innerHTML = clean;
   el.__onSave?.(clean);
   dispatchHtmlUpdate(el);
 }
@@ -525,6 +524,7 @@ export function editElement(el, onSave, clickEvent = null) {
 
   function finish(save) {
     if (save) {
+      el.innerHTML = sanitizeHtml(el.innerHTML.trim());
       updateAndDispatch(el);
     }
     activeEl = null;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- sanitized HTML is now applied only once when finishing text edits to prevent cursor jumps
 - dispatchHtmlUpdate now triggered for every toolbar action to keep widget HTML synchronized
 - toolbar stays visible after editing if the widget remains selected and loaded
   text widgets now receive the `contenteditable` attribute automatically


### PR DESCRIPTION
## Summary
- sanitize text widget HTML only once on save
- note sanitization timing change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685912c123448328991663e761743cc0