### PR TITLE
Fix toolbar activeEl selection

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -213,8 +213,7 @@ async function init() {
       if (!btn) return;
       ev.preventDefault();
       if (!activeEl || !document.body.contains(activeEl)) {
-        const selected = document.querySelector('.canvas-item.selected [contenteditable="true"]');
-        if (selected) activeEl = selected;
+        activeEl = document.querySelector('.canvas-item.selected [contenteditable="true"]');
       }
       if (!activeEl) return;
       const cmd = btn.dataset.cmd;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- ensured toolbar click callback restores the selected editable element when the previous active element is gone
 - toolbar buttons now reliably apply styles to the current editable element and
   the toolbar is reused if it already exists
 - dispatchHtmlUpdate now triggered for every toolbar action to keep widget HTML synchronized


### PR DESCRIPTION
## Summary
- ensure toolbar click handler restores the selected editable when activeEl is missing
- document the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685913003e348328af27b52e2f338a33