### PR TITLE
Remove redundant contenteditable handling

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -587,9 +587,6 @@ export function registerElement(editable, onSave) {
   }
   if (editable.__registered) return;
   editable.__registered = true;
-  if (!editable.hasAttribute('contenteditable')) {
-    editable.setAttribute('contenteditable', 'true');
-  }
   editable.__onSave = onSave;
   const widget = findWidget(editable);
   if (widget) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- registerElement no longer forces the `contenteditable` attribute; `editElement` now fully controls it for safer widget editing
 - toolbar buttons now reliably apply styles to the current editable element and
   the toolbar is reused if it already exists
 - dispatchHtmlUpdate now triggered for every toolbar action to keep widget HTML synchronized


### PR DESCRIPTION
## Summary
- delete `contenteditable` logic from `registerElement`
- document change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859132e5e648328a4132474f9dc65f6