### PR TITLE
Fix italic styles removal in sanitizeHtml

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -49,6 +49,7 @@ export function sanitizeHtml(html) {
           'font-family',
           'text-decoration',
           'font-weight',
+          'font-style',
           'color',
           'background-color'
         ];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- allowed `font-style` inline style in `sanitizeHtml` so italic text survives cleaning
 - ensured toolbar click callback restores the selected editable element when the previous active element is gone
 - sanitized HTML is now applied only once when finishing text edits to prevent cursor jumps
 - toolbar buttons now reliably apply styles to the current editable element and


### PR DESCRIPTION
## Summary
- allow `font-style` inline styles to survive sanitizeHtml
- note addition in changelog

## Testing
- `npm test --silent --color=false`

------
https://chatgpt.com/codex/tasks/task_e_685913f52ca88328a69af154ebff5532