### PR TITLE
Remove autosave from color picker

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -390,7 +390,6 @@ async function init() {
       } else {
         activeEl.style.color = val;
       }
-      updateAndDispatch(activeEl);
       activeEl.focus();
     };
     toolbar.querySelector('.fs-inc').addEventListener('click', () => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- color changes no longer trigger autosave; `applyColor` no longer calls `updateAndDispatch`
 - ensured toolbar click callback restores the selected editable element when the previous active element is gone
 - sanitized HTML is now applied only once when finishing text edits to prevent cursor jumps
 - toolbar buttons now reliably apply styles to the current editable element and


### PR DESCRIPTION
## Summary
- stop applying color changes via updateAndDispatch
- document change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68591411c844832886cfd7870967ab0e