### PR TITLE
Fix toolbar singleton initialization

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -139,8 +139,9 @@ async function init() {
   }
   initPromise = (async () => {
     try {
-      // Reuse existing toolbar if present to avoid duplicate listeners
-      toolbar = document.body.querySelector('.text-block-editor-toolbar');
+      // Ensure toolbar is a singleton to avoid duplicate event listeners
+      toolbar =
+        toolbar || document.body.querySelector('.text-block-editor-toolbar');
       if (!toolbar) {
         toolbar = document.createElement('div');
         toolbar.className = 'text-block-editor-toolbar floating';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- ensured toolbar element is reused if it already exists to prevent duplicate listeners
 - ensured toolbar click callback restores the selected editable element when the previous active element is gone
 - sanitized HTML is now applied only once when finishing text edits to prevent cursor jumps
 - toolbar buttons now reliably apply styles to the current editable element and


### PR DESCRIPTION
## Summary
- ensure text editor toolbar DOM element is reused
- document toolbar reuse in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685913e239308328a08e936a4f895e64