### PR TITLE
Lock widgets while editing

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -506,17 +506,12 @@ export function editElement(el, onSave, clickEvent = null) {
   widget.style.zIndex = '9999';
   widget.classList.add('editing');
 
-  // Only disable dragging while editing but keep widget unlocked
-  widget.setAttribute('gs-locked', 'false');
+  // Lock widget completely while editing to avoid race conditions
+  widget.setAttribute('gs-locked', 'true');
   const grid = widget.closest('.canvas-grid')?.__grid;
-  grid?.update(widget, { locked: false, noMove: true, noResize: false });
+  grid?.update(widget, { locked: true, noMove: true, noResize: true });
 
   if (hitLayer) hitLayer.style.pointerEvents = 'none';
-
-  const block  = () => grid?.update(widget, { noMove: true });
-  const allow  = () => grid?.update(widget, { noMove: false });
-  el.addEventListener('mouseenter', block);
-  el.addEventListener('mouseleave', allow);
 
   el.setAttribute('contenteditable', 'true');
   el.focus();
@@ -544,9 +539,6 @@ export function editElement(el, onSave, clickEvent = null) {
     widget.style.zIndex = String(prevLayer);
     widget.setAttribute('gs-locked', 'false');
     grid?.update(widget, { locked: false, noMove: false, noResize: false });
-
-    el.removeEventListener('mouseenter', block);
-    el.removeEventListener('mouseleave', allow);
     if (el.__inputHandler) {
       el.removeEventListener('input', el.__inputHandler);
       delete el.__inputHandler;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- grid widgets now lock completely during text edits to avoid race conditions
 - registerElement no longer forces the `contenteditable` attribute; `editElement` now fully controls it for safer widget editing
 - fixed grid blocking keyboard input by restoring `contenteditable` removal after finishing edits
 - ensured toolbar click callback restores the selected editable element when the previous active element is gone


### PR DESCRIPTION
## Summary
- disable pointer events on hit layer consistently
- lock widgets when editing to avoid racing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68591404e46c8328ac9c724b60c6a7e7