### PR TITLE
Sanitize HTML only on save

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -15,19 +15,19 @@ function dispatchHtmlUpdate(el) {
   const widget = findWidget(el);
   const instanceId = widget?.dataset.instanceId;
   if (!instanceId) return;
-  const clean = sanitizeHtml(el.innerHTML.trim());
-  console.log('[DEBUG] dispatchHtmlUpdate', instanceId, clean);
+  const html = el.innerHTML.trim();
+  console.log('[DEBUG] dispatchHtmlUpdate', instanceId, html);
   document.dispatchEvent(
     new CustomEvent('widgetHtmlUpdate', {
-      detail: { instanceId, html: clean }
+      detail: { instanceId, html }
     })
   );
 }
 
 function updateAndDispatch(el) {
   if (!el) return;
-  const clean = sanitizeHtml(el.innerHTML.trim());
-  el.__onSave?.(clean);
+  const html = el.innerHTML.trim();
+  el.__onSave?.(html);
   dispatchHtmlUpdate(el);
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- `sanitizeHtml` now runs only on save; live edits no longer sanitize input
 - grid widgets now lock completely during text edits to avoid race conditions
 - ensured toolbar element is reused if it already exists to prevent duplicate listeners
 - color changes no longer trigger autosave; `applyColor` no longer calls `updateAndDispatch`


### PR DESCRIPTION
## Summary
- stop sanitizing widget HTML on each input
- sanitize only when finishing text edits
- note change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859158cb3548328a7ed96572a2b5472