### PR TITLE
Fix editing lock

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -507,10 +507,7 @@ export function editElement(el, onSave, clickEvent = null) {
   widget.style.zIndex = '9999';
   widget.classList.add('editing');
 
-  // Lock widget completely while editing to avoid race conditions
-  widget.setAttribute('gs-locked', 'true');
   const grid = widget.closest('.canvas-grid')?.__grid;
-  grid?.update(widget, { locked: true, noMove: true, noResize: true });
 
   if (hitLayer) hitLayer.style.pointerEvents = 'none';
 
@@ -538,8 +535,6 @@ export function editElement(el, onSave, clickEvent = null) {
 
     widget.dataset.layer = prevLayer;
     widget.style.zIndex = String(prevLayer);
-    widget.setAttribute('gs-locked', 'false');
-    grid?.update(widget, { locked: false, noMove: false, noResize: false });
     if (el.__inputHandler) {
       el.removeEventListener('input', el.__inputHandler);
       delete el.__inputHandler;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- widgets remain movable while editing text; bounding box stays interactive
 - grid widgets now lock completely during text edits to avoid race conditions
 - ensured toolbar element is reused if it already exists to prevent duplicate listeners
 - color changes no longer trigger autosave; `applyColor` no longer calls `updateAndDispatch`


### PR DESCRIPTION
## Summary
- keep widgets movable during text edits
- update changelog

## Testing
- `npm test --prefix BlogposterCMS`

------
https://chatgpt.com/codex/tasks/task_e_6859159a165c83289c5394ec65c706ec