### PR TITLE
Move text toolbar positioning to floating module

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -2,6 +2,7 @@
 // Lightweight global text editor for builder mode.
 import { isValidTag } from '../allowedTags.js';
 import { createColorPicker } from './colorPicker.js';
+import { positionFloatingEl } from './floating-ui.js';
 
 let toolbar = null;
 let activeEl = null;
@@ -631,6 +632,7 @@ export function applyToolbarChange(el, styleProp, value) {
 function showToolbar(el) {
   if (!toolbar) return;
   toolbar.style.display = 'flex';
+  if (el) positionFloatingEl(toolbar, el);
 }
 
 function hideToolbar() {

--- a/BlogposterCMS/public/assets/plainspace/builder/editor/floating-ui.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/floating-ui.js
@@ -1,0 +1,9 @@
+export function positionFloatingEl(el, anchor, offset = 8) {
+  if (!el || !anchor) return;
+  const rect = anchor.getBoundingClientRect();
+  const x = rect.left + window.scrollX + rect.width / 2 - el.offsetWidth / 2;
+  const y = rect.top + window.scrollY - el.offsetHeight - offset;
+  el.style.position = 'absolute';
+  el.style.left = `${Math.max(0, x)}px`;
+  el.style.top = `${Math.max(0, y)}px`;
+}

--- a/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
@@ -21,6 +21,10 @@
 
   &.floating {
     position: absolute;
+    top: auto;
+    left: 0;
+    transform: none;
+    width: auto;
   }
 
   .tb-btn {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- toolbar floating styles defined in SCSS; compiled CSS unchanged
+- toolbar positioning logic moved to new `floating-ui` module
 - grid widgets now lock completely during text edits to avoid race conditions
 - ensured toolbar element is reused if it already exists to prevent duplicate listeners
 - color changes no longer trigger autosave; `applyColor` no longer calls `updateAndDispatch`


### PR DESCRIPTION
## Summary
- create `floating-ui` helper for anchor-based positioning
- float the text editor toolbar near the active element
- tweak floating toolbar styles in SCSS only
- document change in `CHANGELOG`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859158075308328afaf0716a08a87b2