### PR TITLE
Fix builder grid padding for toolbar

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -322,11 +322,13 @@ body.builder-mode #content {
   margin-left: 96px;
   height: calc(100vh - 79px);
   overflow-y: auto;
+  padding-top: 60px; // keep toolbar from covering the grid
+  box-sizing: border-box;
 }
 
 body.builder-mode #builderGrid {
-  height: 100%;
-  min-height: 100%;
+  height: calc(100% - 60px);
+  min-height: calc(100% - 60px);
 }
 
 // Ensure themed widget content matches its wrapper dimensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ El Psy Kongroo
 ## [Unreleased]
 - toolbar floating styles defined in SCSS; compiled CSS unchanged
 - toolbar positioning logic moved to new `floating-ui` module
+- builder grid now starts below the fixed toolbar to avoid overlap
 - widgets remain movable while editing text; bounding box stays interactive
 - `sanitizeHtml` now runs only on save; live edits no longer sanitize input
 - grid widgets now lock completely during text edits to avoid race conditions


### PR DESCRIPTION
## Summary
- keep builder grid below the fixed text toolbar
- document change in changelog

## Testing
- `npm test --silent`
- `npm run placeholder-parity --silent`

------
https://chatgpt.com/codex/tasks/task_e_685919c2494883288ddb473d4039552c