### PR TITLE
Fix text block toolbar width

### DIFF
--- a/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
@@ -6,9 +6,10 @@
 .text-block-editor-toolbar {
   position: fixed;
   top: 60px; // floats just below the header
-  left: 50%;
-  transform: translateX(-50%);
-  width: calc(100% - 32px); // almost full width with small margins
+  left: 96px; // align with builder grid offset
+  right: 0;
+  width: auto; // stretch across the grid
+  transform: none;
   display: flex;
   align-items: center;
   gap: 4px;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- text block editor toolbar now spans the builder grid width and stays fixed on top
 - toolbar floating styles defined in SCSS; compiled CSS unchanged
 - toolbar positioning logic moved to new `floating-ui` module
 - builder grid now starts below the fixed toolbar to avoid overlap


### PR DESCRIPTION
## Summary
- ensure the text block editor toolbar stretches across the builder grid
- document toolbar width update in changelog

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_68591dd5f7b88328ae91bdb6db28461c