### PR TITLE
Fix text block toolbar width

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
@@ -180,7 +180,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null, startLaye
     if (!el) return;
     const editable = getRegisteredEditable(el);
     setActiveElement(editable);
-    showToolbar(el);
+    showToolbar();
   }
   grid.on('change', el => {          // jedes Mal, wenn das Grid ein Widget anfasst …
     if (el) selectWidget(el);        // … Action-Bar zeigen

--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -2,7 +2,6 @@
 // Lightweight global text editor for builder mode.
 import { isValidTag } from '../allowedTags.js';
 import { createColorPicker } from './colorPicker.js';
-import { positionFloatingEl } from './floating-ui.js';
 
 let toolbar = null;
 let activeEl = null;
@@ -220,7 +219,7 @@ async function init() {
         toolbar || document.body.querySelector('.text-block-editor-toolbar');
       if (!toolbar) {
         toolbar = document.createElement('div');
-        toolbar.className = 'text-block-editor-toolbar floating';
+        toolbar.className = 'text-block-editor-toolbar';
         toolbar.style.display = 'none';
         toolbar.innerHTML = [
         '<div class="font-family-control">' +
@@ -597,7 +596,7 @@ export function editElement(el, onSave, clickEvent = null) {
   el.addEventListener('input', inputHandler);
   el.__inputHandler = inputHandler;
 
-  showToolbar(el);
+  showToolbar();
 
   function finish(save) {
     if (save) {
@@ -619,7 +618,7 @@ export function editElement(el, onSave, clickEvent = null) {
 
     widget.classList.remove('editing');
     if (widget.classList.contains('selected')) {
-      showToolbar(widget);
+      showToolbar();
     } else {
       hideToolbar();
     }
@@ -698,10 +697,9 @@ export function applyToolbarChange(el, styleProp, value) {
   updateAndDispatch(el);
 }
 
-function showToolbar(el) {
+function showToolbar() {
   if (!toolbar) return;
   toolbar.style.display = 'flex';
-  if (el) positionFloatingEl(toolbar, el);
 }
 
 function hideToolbar() {

--- a/BlogposterCMS/public/assets/plainspace/builder/editor/floating-ui.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/floating-ui.js
@@ -1,9 +1,0 @@
-export function positionFloatingEl(el, anchor, offset = 8) {
-  if (!el || !anchor) return;
-  const rect = anchor.getBoundingClientRect();
-  const x = rect.left + window.scrollX + rect.width / 2 - el.offsetWidth / 2;
-  const y = rect.top + window.scrollY - el.offsetHeight - offset;
-  el.style.position = 'absolute';
-  el.style.left = `${Math.max(0, x)}px`;
-  el.style.top = `${Math.max(0, y)}px`;
-}

--- a/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
+++ b/BlogposterCMS/public/assets/scss/components/_text-editor-toolbar.scss
@@ -1,14 +1,15 @@
 /* =============================================================================
    components/_text-editor-toolbar.scss
-   Styles for the floating text block editor toolbar
+   Styles for the fixed text block editor toolbar
    ============================================================================= */
 
 .text-block-editor-toolbar {
   position: fixed;
-  top: 60px; // floats just below the header
-  left: 50%;
-  transform: translateX(-50%);
-  width: calc(100% - 32px); // almost full width with small margins
+  top: 60px; // fixed just below the header
+  left: 96px; // align with builder grid offset
+  right: 0;
+  width: auto; // stretch across the grid
+  transform: none;
   display: flex;
   align-items: center;
   gap: 4px;
@@ -19,13 +20,6 @@
   box-shadow: var(--shadow-default);
   z-index: 1000;
 
-  &.floating {
-    position: absolute;
-    top: auto;
-    left: 0;
-    transform: none;
-    width: auto;
-  }
 
   .tb-btn {
     background: transparent;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
-- toolbar floating styles defined in SCSS; compiled CSS unchanged
-- toolbar positioning logic moved to new `floating-ui` module
+- text block editor toolbar now spans the builder grid width and stays fixed below the header
+- toolbar no longer floats near widgets; removed `floating-ui` helper
 - builder grid now starts below the fixed toolbar to avoid overlap
 - widgets remain movable while editing text; bounding box stays interactive
 - `sanitizeHtml` now runs only on save; live edits no longer sanitize input


### PR DESCRIPTION
## Summary
- ensure the text block editor toolbar stays fixed under the builder header
- remove floating-ui helper and update SCSS
- document toolbar behavior change in changelog

## Testing
- `npm test`
- `npm run placeholder-parity`


------
https://chatgpt.com/codex/tasks/task_e_68591dd5f7b88328ae91bdb6db28461c