### PR TITLE
Fix styling toggle removal in text editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- fixed bold, italic and underline toggles correctly remove styling instead of nesting spans
 - text block editor toolbar now spans the builder grid width and stays fixed below the header
 - toolbar no longer floats near widgets; removed `floating-ui` helper
 - builder grid now starts below the fixed toolbar to avoid overlap


### PR DESCRIPTION
## Summary
- adjust toggleStyleInternal to unwrap existing spans rather than nesting new ones
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68593ca23f18832897f25e7b0caf9621