### PR TITLE
Fix color picker closing too early

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -281,6 +281,7 @@ async function init() {
       }
       updateAndDispatch(activeEl);
       activeEl.focus();
+      updateAndDispatch(activeEl);
     };
 
     toolbar.addEventListener('click', ev => {
@@ -322,7 +323,6 @@ async function init() {
       onSelect: c => {
         applyColor(c);
         colorIcon.style.textDecorationColor = c;
-        colorPicker.hide();
       },
       onClose: () => colorBtn.focus()
     });
@@ -340,9 +340,13 @@ async function init() {
       }
     });
     toolbar.addEventListener('click', ev => {
+      if (!colorPicker.el.contains(ev.target)) return;
+    });
+
+    document.addEventListener('click', ev => {
       if (
-        !colorWrapper.contains(ev.target) &&
-        !colorPicker.el.contains(ev.target)
+        !colorPicker.el.contains(ev.target) &&
+        !toolbar.contains(ev.target)
       ) {
         colorPicker.hide();
       }
@@ -467,6 +471,7 @@ async function init() {
         activeEl.style.color = val;
       }
       activeEl.focus();
+      updateAndDispatch(activeEl);
     };
     toolbar.querySelector('.fs-inc').addEventListener('click', () => {
       applySize((parseFloat(fsInput.value) || 16) + 1);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- fixed color picker closing immediately after selecting a color; picker now only
+  hides on outside clicks or via the close button
 - text block editor toolbar now spans the builder grid width and stays fixed below the header
 - toolbar no longer floats near widgets; removed `floating-ui` helper
 - builder grid now starts below the fixed toolbar to avoid overlap


### PR DESCRIPTION
## Summary
- keep color picker open when selecting a color
- adjust toolbar listeners to hide the picker on outside clicks only
- ensure color updates dispatch changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68593cbe132c83288805fdd010190ed2