### PR TITLE
Fix autoEdit registration delay

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -683,10 +683,12 @@ export function enableAutoEdit() {
     const widget = findWidget(ev.target);
     if (!widget || !widget.classList.contains('selected')) return;
     let el = findEditableFromEvent(ev);
+    if (!el) el = getRegisteredEditable(widget);
+    /*  Neu:  Ist noch nichts registriert?  ->  kurz warten und neu triggern  */
     if (!el) {
-      el = getRegisteredEditable(widget);
+      setTimeout(() => widget.dispatchEvent(new Event('dblclick')), 30);
+      return;
     }
-    if (!el) return;
     ev.stopPropagation();
     ev.preventDefault();
     editElement(el, el.__onSave, ev);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- autoEdit now retries entering edit mode if a widget hasn't registered its editable element yet
 - fixed color picker closing immediately after selecting a color; picker now only
   hides on outside clicks or via the close button
 - toolbar actions now work on the selected widget even before entering edit mode


### PR DESCRIPTION
## Summary
- retry double-click editing if widget editables aren't registered yet
- document autoEdit retry in changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859599f488c832885f397fd17b67f7f