### PR TITLE
Auto-select dropped widget

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
@@ -371,6 +371,9 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null, startLaye
     gridEl.appendChild(wrapper);
     grid.makeWidget(wrapper);
 
+    /* --------  Neu: automatisch auswählen  --------------------------- */
+    selectWidget(wrapper);          // ruft Action-Bar & widgetSelected
+
     renderWidget(wrapper, widgetDef, localCodeMap);
     if (pageId) scheduleAutosave();
   });

--- a/BlogposterCMS/public/assets/scss/components/_builder.scss
+++ b/BlogposterCMS/public/assets/scss/components/_builder.scss
@@ -518,11 +518,13 @@ body.preview-desktop #content {
   cursor: move;
 }
 
-.canvas-item.editing { 
-  z-index: 9999; 
+.canvas-item.editing {
+  z-index: 9999;
+  cursor: text;
 }
 
 .canvas-item.selected .hit-layer,
 .canvas-item.editing .hit-layer {
   pointer-events: none;
+  cursor: text;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- widgets dropped onto the canvas are automatically selected and editing shows a text cursor
 - fixed color picker closing immediately after selecting a color; picker now only
   hides on outside clicks or via the close button
 - toolbar actions now work on the selected widget even before entering edit mode


### PR DESCRIPTION
## Summary
- auto-select widget after dropping onto the canvas
- show text cursor when editing widgets
- document changes in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685959b229088328bb13e89cee77b0fe