### PR TITLE
Fix custom event bubbling in builder

### DIFF
--- a/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/builderRenderer.js
@@ -211,7 +211,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null, startLaye
     }
     actionBar.style.display = 'none';
     state.activeWidgetEl.classList.remove('selected');
-    state.activeWidgetEl.dispatchEvent(new Event('deselected'));
+    state.activeWidgetEl.dispatchEvent(new Event('deselected', { bubbles: true }));
     state.activeWidgetEl = null;
     hideToolbar();
   grid.clearSelection();
@@ -374,6 +374,7 @@ export async function initBuilder(sidebarEl, contentEl, pageId = null, startLaye
 
     /* --------  Neu: automatisch auswählen  --------------------------- */
     selectWidget(wrapper);          // ruft Action-Bar & widgetSelected
+    wrapper.dispatchEvent(new Event('selected', { bubbles: true }));
 
     renderWidget(wrapper, widgetDef, localCodeMap);
     if (pageId) scheduleAutosave();

--- a/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/editor/editor.js
@@ -591,7 +591,7 @@ export function editElement(el, onSave, clickEvent = null) {
   widget.dataset.layer = 9999;
   widget.style.zIndex = '9999';
   widget.classList.add('editing');
-  widget.dispatchEvent(new Event('editStart'));
+  widget.dispatchEvent(new Event('editStart', { bubbles: true }));
 
   //lock the widget to prevent moving/resizing while editing
   widget.setAttribute('gs-locked', 'true');
@@ -634,7 +634,7 @@ export function editElement(el, onSave, clickEvent = null) {
     if (hitLayer) hitLayer.style.pointerEvents = 'auto';
 
     widget.classList.remove('editing');
-    widget.dispatchEvent(new Event('editEnd'));
+    widget.dispatchEvent(new Event('editEnd', { bubbles: true }));
     if (widget.classList.contains('selected')) {
       showToolbar();
     } else {
@@ -688,7 +688,8 @@ export function enableAutoEdit() {
     if (!el) el = getRegisteredEditable(widget);
     /*  Neu:  Ist noch nichts registriert?  ->  kurz warten und neu triggern  */
     if (!el) {
-      setTimeout(() => widget.dispatchEvent(new Event('dblclick')), 30);
+      setTimeout(() =>
+        widget.dispatchEvent(new Event('dblclick', { bubbles: true })), 30);
       return;
     }
     ev.stopPropagation();
@@ -732,7 +733,8 @@ function hideToolbar() {
   }
 }
 
-document.addEventListener('selected', () => hideToolbar());
+document.addEventListener('selected',   () => hideToolbar());
+document.addEventListener('deselected', () => hideToolbar());
 
 export { showToolbar, hideToolbar };
 

--- a/BlogposterCMS/public/assets/plainspace/builder/managers/eventManager.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/managers/eventManager.js
@@ -11,7 +11,7 @@ export function registerDeselect(gridEl, state, actionBar, hideToolbar) {
     }
     actionBar.style.display = 'none';
     state.activeWidgetEl.classList.remove('selected');
-    state.activeWidgetEl.dispatchEvent(new Event('deselected'));
+    state.activeWidgetEl.dispatchEvent(new Event('deselected', { bubbles: true }));
     state.activeWidgetEl = null;
     hideToolbar();
     gridEl.__grid.clearSelection();

--- a/BlogposterCMS/public/assets/plainspace/builder/renderer/actionBar.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/renderer/actionBar.js
@@ -31,14 +31,14 @@ export function createActionBar(selectWidget, grid, state, scheduleAutosave) {
     if (!el) return;
     if (state.activeWidgetEl) {
       state.activeWidgetEl.classList.remove('selected');
-      state.activeWidgetEl.dispatchEvent(new Event('deselected'));
+      state.activeWidgetEl.dispatchEvent(new Event('deselected', { bubbles: true }));
     }
     state.activeWidgetEl = el;
     const editable = window.getRegisteredEditable
       ? window.getRegisteredEditable(el)
       : null;
     if (editable) window.setActiveElement(editable);
-    el.dispatchEvent(new Event('selected'));
+    el.dispatchEvent(new Event('selected', { bubbles: true }));
     state.activeWidgetEl.classList.add('selected');
     grid.select(el);
     const locked = el.getAttribute('gs-locked') === 'true';
@@ -66,7 +66,7 @@ export function createActionBar(selectWidget, grid, state, scheduleAutosave) {
     if (!state.activeWidgetEl) return;
     const target = state.activeWidgetEl;
     target.classList.remove('selected');
-    target.dispatchEvent(new Event('deselected'));
+    target.dispatchEvent(new Event('deselected', { bubbles: true }));
     grid.removeWidget(target);
     actionBar.style.display = 'none';
     state.activeWidgetEl = null;

--- a/BlogposterCMS/public/assets/plainspace/builder/utils.js
+++ b/BlogposterCMS/public/assets/plainspace/builder/utils.js
@@ -25,6 +25,9 @@ export function addHitLayer(widget) {
   widget.addEventListener('editEnd', toggle);
   widget.addEventListener('selected', toggle);
   widget.addEventListener('deselected', toggle);
+
+  // Set initial state
+  toggle();
 }
 
 export function scopeThemeCss(css, rootPrefix, contentPrefix) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 El Psy Kongroo
 
 ## [Unreleased]
+- custom widget events now bubble up to the document
+- hit-layer initializes its state immediately
 - autoEdit now retries entering edit mode if a widget hasn't registered its editable element yet
 - widgets dropped onto the canvas are automatically selected and editing shows a text cursor
 - hit-layer now disables pointer events while a widget is being edited or when the action bar is visible


### PR DESCRIPTION
## Summary
- bubble widget events so document-level listeners work
- initialize hit-layer state immediately
- dispatch selection event when dropping a widget
- retry auto edit with bubbling dblclick
- close toolbar when a widget is deselected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685960a0b92c8328aa32dd11f8107468